### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Teradata MCP Server Template
 
 ### Overview
@@ -29,6 +28,10 @@ We are providing three sets of tools
 We have also created a custom_tools section that will allow for the development of customer tools to be easily added.
 
 The Test directory contains a simple ClientChatBot tool for testing tools.
+
+<a href="https://glama.ai/mcp/servers/@Teradata/teradata-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Teradata/teradata-mcp-server/badge" alt="Teradata Server MCP server" />
+</a>
 
 ### Environment Set Up
 Step 1 - The environment has been put together assuming you have the uv package installed on your local machine.  Installation instructions for uv can be found at https://github.com/astral-sh/uv 
@@ -152,7 +155,7 @@ SSE=False
                 "command": "uv",
                 "args": [
                     "--directory",
-                    "/Users/Daniel.Tehan/Code/MCP/teradata-mcp-server/src/teradata_mcp_server/,
+                    "/Users/Daniel.Tehan/Code/MCP/teradata-mcp-server/src/teradata_mcp_server/",
                     "run",
                     "server.py"
                 ]
@@ -217,5 +220,3 @@ Access the UI at http://localhost:8080.
 To add the MCP tools, navigate to Settings > Tools > Add Connection, and enter your mcpo server connection details (eg. `localhost:8001`, password = `top-secret` if you have executed the command line in the mcpo section).
 
 You should be able to see the tools in the Chat Control Valves section on the right and get your models to use it.
-
-  


### PR DESCRIPTION
This PR adds a badge for the [Teradata MCP Server](https://glama.ai/mcp/servers/@Teradata/teradata-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Teradata/teradata-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Teradata/teradata-mcp-server/badge" alt="Teradata Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.