### PR TITLE
Update documentation paths from scripts/client_examples to examples

### DIFF
--- a/docs/client_guide/CLIENT_GUIDE.md
+++ b/docs/client_guide/CLIENT_GUIDE.md
@@ -21,7 +21,7 @@ There are many client options that you can choose from, they each have different
 - [teradata-trusted-data-agent](https://github.com/rgeissen/teradata-trusted-data-agent)
 
 ## Audio Client
-- [MCP Voice Client](../../scripts/client_examples/MCP_VoiceClient/README.md)
+- [MCP Voice Client](../../examples/MCP_VoiceClient/README.md)
 
 ## Code Clients
 - [Visual Studio Code](./Visual_Studio_Code.md)

--- a/docs/client_guide/Claude_desktop.md
+++ b/docs/client_guide/Claude_desktop.md
@@ -8,7 +8,7 @@ Modify your claude desktop configuration file -  `claude_desktop_config.json` co
 
 The simplest option is to start the mcp server with Claude and enable communication over stdio
 
-Example can be found in [claude_desktop_stdio_config](../../scripts/client_examples/Claude_Desktop_Config_Files/claude_desktop_stdio_config)
+Example can be found in [claude_desktop_stdio_config](../../examples/Claude_Desktop_Config_Files/claude_desktop_stdio_config)
 
 Note: you will need to modify the directory path in the args for your system, this needs to be a complete path.  You may also need to have a complete path to uv in the command as well.
 
@@ -20,7 +20,7 @@ Note: The PROFILE variable is optional, you can change its value to instantiate 
 
 If you have a Teradata MCP Server instance running and available via http (1), you can connect to it using the [mcp-remote npx package](https://www.npmjs.com/package/mcp-remote).
 
-Example can be found in [claude_desktop_http_config](../../test/Claude_Desktop_Config_Files/claude_desktop_http_config)
+Example can be found in [claude_desktop_http_config](../../examples/Claude_Desktop_Config_Files/claude_desktop_http_config)
 
 Note: The Claude Desktop example assumes a server running locally on port 8001 - modify as needed.
 
@@ -30,6 +30,6 @@ Note (1): See UV or Docker options in the [Getting Started](../GETTING_STARTED.m
 
 Warning: We are not actively maintaining and testing the SSE functionality.
 
-Example can be found in [claude_desktop_SSE_config](../../scripts/client_examples/Claude_Desktop_Config_Files/claude_desktop_SSE_config)
+Example can be found in [claude_desktop_SSE_config](../../examples/Claude_Desktop_Config_Files/claude_desktop_SSE_config)
 
 Note: you may need to modify the host in the args.


### PR DESCRIPTION
Fixed broken links in client guide documentation by updating paths to point to the correct examples directory structure.