### PR TITLE
Fixing Inconsistencies

### DIFF
--- a/src/teradata_mcp_server/tools/qlty/qlty_tools.py
+++ b/src/teradata_mcp_server/tools/qlty/qlty_tools.py
@@ -69,7 +69,7 @@ def handle_qlty_distinctCategories(
     conn: TeradataConnection,
     database_name: str | None,
     table_name: str,
-    col_name: str,
+    column_name: str,
     *args,
     **kwargs
 ):
@@ -106,7 +106,7 @@ def handle_qlty_standardDeviation(
     conn: TeradataConnection,
     database_name: str | None,
     table_name: str,
-    col_name: str,
+    column_name: str,
     *args,
     **kwargs
 ):
@@ -174,7 +174,7 @@ def handle_qlty_univariateStatistics(
     conn: TeradataConnection,
     database_name: str | None,
     table_name: str,
-    col_name: str,
+    column_name: str,
     *args,
     **kwargs
 ):
@@ -212,7 +212,7 @@ def handle_qlty_rowsWithMissingValues(
     conn: TeradataConnection,
     database_name: str | None,
     table_name: str,
-    col_name: str,
+    column_name: str,
     *args,
     **kwargs
 ):


### PR DESCRIPTION
there have been still two inconsistencies left (don't know where those are coming from) ... hereby they are fixed (col_name to column_name) - as what I see those have been the only 2 occasions in all tool files. There are still two areas where col_name is used (see screenshot) - if those are relevant for exposing tools/prompts please correct them.
<img width="379" height="331" alt="Bildschirmfoto 2025-08-18 um 14 53 56" src="https://github.com/user-attachments/assets/4a0085b4-0aa6-487d-8d77-0341716be0ad" />
