### PR TITLE
Updated Dockerfile to support fs and evs pip package to install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY ./src /app/src
 # Build and install the package
 RUN uv build && \
     pip install . && \
+    if [ "$ENABLE_FS_MODULE" = "true" ]; then pip install .[fs];fi && \
+    if [ "$ENABLE_EVS_MODULE" = "true" ]; then pip install .[evs];fi && \
     apt-get purge -y build-essential gcc && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
when we passed Docker image build arguments - 
`ENABLE_FS_MODULE=true` and `ENABLE_EVS_MODULE=true` Dockerfile was not taking those field to install `teradataml `and `teradatagenai `library so fixed it.

Tested 

<img width="3782" height="1855" alt="image" src="https://github.com/user-attachments/assets/ddf4ce96-03bc-4350-b774-6070ba7af90c" />
