### PR TITLE
docs: add gemini-cli version 0.1.9 requirement and increase timeout

### DIFF
--- a/docs/client_guide/Google_Gemini_CLI.md
+++ b/docs/client_guide/Google_Gemini_CLI.md
@@ -2,6 +2,11 @@
 
 > **📍 Navigation:** [Documentation Home](../README.md) | [Server Guide](../README.md#-server-guide) | [Getting started](../server_guide/GETTING_STARTED.md) | [Architecture](../server_guide/ARCHITECTURE.md) | [Installation](../server_guide/INSTALLATION.md) | [Configuration](../server_guide/CONFIGURATION.md) | [Security](../server_guide/SECURITY.md) | [Customization](../server_guide/CUSTOMIZING.md) | [Client Guide](CLIENT_GUIDE.md)
 
+> **⚠️ Version Compatibility Notice:** This integration requires gemini-cli version 0.1.9. Use the following command to run the correct version:
+> ```bash
+> npx @google/gemini-cli@0.1.9
+> ```
+
 1.	Make sure you have Teradata database access. (the most convenient way: Go to https://clearscape.teradata.com create account and login, start the environment and click on Run Demo)
 2.	Go to https://github.com/Teradata/teradata-mcp-server run below lines in cmd terminal. (once build finished, you should see Teradata-mcp-server image in your docker desktop)
     * ```export DATABASE_URI=teradata://username:password@host:1025``` (use the username, password, host from above clearscape step)
@@ -19,9 +24,11 @@
     "mcpServers": {
         "teradata-http": {
             "httpUrl" : "http://127.0.0.1:8001/mcp/",
-            "timeout" : 5000
+            "timeout" : 300000
         }
     }
 }
 ```
-5. Open a cmd terminal, type ```gemini``` and hit enter, now you should see gemini-cli interface.
+    * **Note:** The timeout is set to 300000ms (5 minutes) to accommodate long-running analytical operations like clustering. Adjust if needed.
+5. Open a cmd terminal, type ```npx @google/gemini-cli@0.1.9``` and hit enter, now you should see gemini-cli interface.
+    * **Note:** Using version 0.1.9 is required for compatibility with the Teradata MCP server.


### PR DESCRIPTION
- Add version compatibility warning for gemini-cli 0.1.9
- Update timeout from 5000ms to 300000ms (5 minutes)
- Update instructions to use specific version command
- Add notes explaining timeout adjustment for long-running operations

This resolves timeout issues with computationally intensive MCP operations like clustering and complex analytics queries.