### PR TITLE
Fix tdvs tools by filtering None kwargs (issue #254)

### DIFF
--- a/src/teradata_mcp_server/tools/tdvs/tdvs_tools.py
+++ b/src/teradata_mcp_server/tools/tdvs/tdvs_tools.py
@@ -142,7 +142,8 @@ def handle_tdvs_similarity_search(conn: TeradataConnection, vs_name: str, vs_sim
     try:
         create_teradataml_context()
         vs = VectorStore(vs_name)
-        data = vs.similarity_search(**vs_similaritysearch.model_dump())
+        search_kwargs = {k: v for k, v in vs_similaritysearch.model_dump().items() if v is not None}
+        data = vs.similarity_search(**search_kwargs)
         metadata = { "tool_name": "tdvs_similarity_search" }
         return create_response(data, metadata)
     except Exception as e:
@@ -156,7 +157,8 @@ def handle_tdvs_ask(conn: TeradataConnection, vs_name: str, vs_ask: VectorStoreA
         create_teradataml_context()
         VSManager.health()
         vs = VectorStore(name=vs_name)
-        response = vs.ask(**vs_ask.model_dump())
+        ask_kwargs = {k: v for k, v in vs_ask.model_dump().items() if v is not None}
+        response = vs.ask(**ask_kwargs)
         metadata = { "tool_name": "tdvs_ask" }
         return create_response(response, metadata)
     except Exception as e:


### PR DESCRIPTION
## Summary
Fixes an issue where `tdvs_ask` and `tdvs_similarity_search` returned `null` results. 

The MCP tool handlers were forwarding `None` values to the Teradata Vector Store, which caused unexpected behavior. This change filters out `None` fields before invoking the underlying SDK methods.

## Related Issue
Fixes #254

## Assistance from

 Snigda Biswas (SE AI Platform) 

## Changes
- Filter out `None` values before calling:
  - `vs.ask(...)`
  - `vs.similarity_search(...)`

## Testing
Tests were run locally using UES authentication

Command:
```bash
uv run python tests/run_mcp_tests.py \
  "uv run teradata-mcp-server --profile all" \
  "tests/cases/tdvs_test_cases.json" \
  --verbose

Results:

[02/10/26 13:28:58] INFO     Starting MCP server 'teradata-mcp-server' with transport 'stdio'                                                                                                                                          server.py:1493
✓ Connected to MCP server
✓ Discovered 56 available tools
✓ Found test cases for 5 tools

✓ Tools with tests: tdvs_ask, tdvs_get_details, tdvs_get_health, tdvs_list, tdvs_similarity_search
⚠ Tools without tests: base_columnDescription, base_databaseList, base_readQuery, base_tableAffinity, base_tableDDL, base_tableList, base_tablePreview, base_tableUsage, dba_databaseSpace, dba_databaseVersion, dba_featureUsage, dba_flowControl, dba_resusageSummary, dba_sessionInfo, dba_systemSpace, dba_tableSpace, dba_tableSqlList, dba_tableUsageImpact, dba_userDelay, dba_userSqlList, fs_createDataset, fs_featureStoreContent, fs_getAvailableDatasets, fs_getAvailableEntities, fs_getDataDomains, fs_getFeatureDataModel, fs_getFeatures, fs_isFeatureStorePresent, plot_line_chart, plot_pie_chart, plot_polar_chart, plot_radar_chart, qlty_columnSummary, qlty_distinctCategories, qlty_missingValues, qlty_negativeValues, qlty_rowsWithMissingValues, qlty_standardDeviation, qlty_univariateStatistics, rag_Execute_Workflow, sec_rolePermissions, sec_userDbPermissions, sec_userRoles, sql_Analyze_Cluster_Stats, sql_Execute_Full_Pipeline, sql_Retrieve_Cluster_Queries, tdvs_create, tdvs_destroy, tdvs_grant_user_permission, tdvs_revoke_user_permission, tdvs_update

Running 5 test cases...
────────────────────────────────────────────────────────────
  Running tdvs_get_health:test_get_vs_health... PASS (8.12s)
  Running tdvs_get_details:test_vs_get_details... PASS (8.71s)
  Running tdvs_list:test_vs_list... PASS (5.46s)
  Running tdvs_similarity_search:test_vs_similarity_search... PASS (6.79s)
  Running tdvs_ask:test_vs_ask... PASS (7.62s)

────────────────────────────────────────────────────────────
Tests completed

================================================================================
PERFORMANCE
================================================================================
Total Time: 36.70s
Average Time: 7.34s per test

================================================================================
TEST REPORT
================================================================================
Total Tests: 5
Passed: 5
Failed: 0
Warnings: 0
Success Rate: 100.0%
Detailed results saved to: var/test-reports/test_report_20260210_132935.json

--- MCP Server Log Output ---
➜  teradata-mcp-server git:(fix/tdvs-ask-filter-none-issue-254) ✗ 
