### PR TITLE
Extend wildcard normalization to include 'all' and fix dba_databaseSpace schema

### DIFF
--- a/src/teradata_mcp_server/tools/base/base_tools.py
+++ b/src/teradata_mcp_server/tools/base/base_tools.py
@@ -130,8 +130,8 @@ def handle_base_tableList(conn: TeradataConnection, database_name: str | None = 
     """
     logger.debug(f"Tool: handle_base_tableList: Args: database_name: {database_name}")
 
-    # Treat wildcards as "all" (planner may pass * or % instead of omitting)
-    if database_name and database_name.strip() in ("*", "%"):
+    # Treat wildcards as "all" (planner may pass *, %, or "all" instead of omitting)
+    if database_name and database_name.strip().lower() in ("*", "%", "all"):
         database_name = None
 
     sql = "select TableName from dbc.TablesV tv where tv.TableKind in ('T','V', 'O', 'Q')"
@@ -398,8 +398,8 @@ def handle_base_tableUsage(conn: TeradataConnection, database_name: str | None =
 
     logger.debug("Tool: handle_base_tableUsage: Args: database_name:")
 
-    # Treat wildcards as "all" (planner may pass * or % instead of omitting)
-    if database_name and database_name.strip() in ("*", "%"):
+    # Treat wildcards as "all" (planner may pass *, %, or "all" instead of omitting)
+    if database_name and database_name.strip().lower() in ("*", "%", "all"):
         database_name = None
 
     database_name_filter = f"AND objectdatabasename = '{database_name}'" if database_name else ""

--- a/src/teradata_mcp_server/tools/dba/dba_tools.py
+++ b/src/teradata_mcp_server/tools/dba/dba_tools.py
@@ -189,7 +189,7 @@ def handle_dba_tableSpace(conn: TeradataConnection, database_name: str | None = 
 
 #------------------ Tool  ------------------#
 # Get database space tool
-def handle_dba_databaseSpace(conn: TeradataConnection, database_name: str | None | None, *args, **kwargs):
+def handle_dba_databaseSpace(conn: TeradataConnection, database_name: str | None = None, *args, **kwargs):
     """
     Get database space if database name is provided, otherwise get all databases space allocations.
 
@@ -201,8 +201,8 @@ def handle_dba_databaseSpace(conn: TeradataConnection, database_name: str | None
     """
     logger.debug(f"Tool: handle_dba_databaseSpace: Args: database_name: {database_name}")
 
-    # Treat wildcards as "all databases" (planner may pass * or % instead of omitting)
-    if database_name and database_name.strip() in ("*", "%"):
+    # Treat wildcards as "all databases" (planner may pass *, %, or "all" instead of omitting)
+    if database_name and database_name.strip().lower() in ("*", "%", "all"):
         database_name = None
 
     database_name_filter = f"AND objectdatabasename = '{database_name}'" if database_name else ""


### PR DESCRIPTION
## Summary

- Add `"all"` (case-insensitive) to existing wildcard normalization (`*`, `%`) on `database_name` parameters in `base_tableList`, `base_tableUsage`, and `dba_databaseSpace`
- Fix `dba_databaseSpace` type annotation from `str | None | None` (duplicate None, no default) to `str | None = None`, correcting the JSON schema from `required: true` to `required: false`

## Motivation

PR #256 introduced wildcard normalization for `*` and `%`. Testing revealed two additional gaps:

1. **Missing `"all"` pattern:** LLM agents sometimes pass `database_name="all"` to express "return all databases." The SQL query then executes `WHERE DatabaseName = 'all'`, returning zero rows with no error — the agent proceeds with empty data. Adding `"all"` to the normalization set closes this gap.

2. **Schema annotation bug:** `database_name: str | None | None` had a duplicate `None` union member without a default value. FastMCP interpreted this as `"required": true` in the JSON schema. When an LLM agent correctly omits the parameter (meaning "all databases"), the MCP server rejects the call, forcing a retry.

## Changes

**base_tools.py:**
- `handle_base_tableList`, `handle_base_tableUsage`: Add `"all"` (case-insensitive) to wildcard check

**dba_tools.py:**
- `handle_dba_databaseSpace`: Add `"all"` to wildcard check + fix type from `str | None | None` to `str | None = None`

## Test plan

- [ ] Verify `database_name="all"` / `"All"` / `"ALL"` returns same results as `database_name=None`
- [ ] Verify `dba_databaseSpace()` with no arguments succeeds (no schema validation error)
- [ ] Verify existing `*` and `%` normalization still works
- [ ] Verify normal database names are unaffected