### PR TITLE
Harden dba_databaseHealthAssessment date handling, expand analytics, and fix no_days precedence

### DIFF
--- a/src/teradata_mcp_server/tools/dba/dba_objects.yml
+++ b/src/teradata_mcp_server/tools/dba/dba_objects.yml
@@ -273,22 +273,28 @@ dba_databaseHealthAssessment :
   prompt: |
     Generate a comprehensive Teradata system health dashboard for the last 30 days, structured as an executive summary followed by detailed technical analysis.
 
-    ## Phase 1 - Get list of databases
+    ## Phase 1 - Get list of databases and space metrics
     Use base_databaseList tool with scope='{database_scope}' to get a list of databases.
     Create a list of database names for the phases below.
     Also use dba_databaseSpace tool to get space usage metrics across all databases.
+    Also use dba_tableSpace tool with top_n=10 and exclude_system=true to get the top 10 space-consuming tables.
 
     ## Phase 2 - Resource usage analysis for the last 30 days
-    Use dba_resusageSummary tool to gather CPU, IO, and Memory resource usage patterns for the last 30 days.
-    Collect both summary dimensions and heatmap dimensions (by weekday and hour of day).
+    Use dba_resusageSummary tool with no_days=30 to gather CPU, IO, and Memory resource usage patterns.
+    The tool uses no_days to calculate the date range internally - do NOT pass a date parameter.
+    Call the tool twice:
+      1. First call with dimensions=["LogDate"] for the daily summary trend
+      2. Second call with dimensions=["LogDate","hourOfDay"] for the 30-day heatmap (date x hour matrix)
 
     ## Phase 3 - Flow control analysis for the last 30 days
-    Use dba_flowControl tool to gather flow control metrics for the last 30 days.
-    The tool accepts start_date and end_date parameters in YYYY-MM-DD format.
+    IMPORTANT: This is a SINGLE tool call, not a date iteration. Do NOT generate a date list or iterate per day.
+    Use dba_flowControl tool ONCE with start_date = 30 days before today and end_date = today, both in YYYY-MM-DD format.
+    Calculate these dates yourself and pass them directly as arguments.
 
     ## Phase 4 - User delay analysis for the last 30 days
-    Use dba_userDelay tool to gather user delay data for the last 30 days.
-    The tool accepts start_date and end_date parameters in YYYY-MM-DD format.
+    IMPORTANT: This is a SINGLE tool call, not a date iteration. Do NOT generate a date list or iterate per day.
+    Use dba_userDelay tool ONCE with the same date range as Phase 3: start_date = 30 days before today, end_date = today, both in YYYY-MM-DD format.
+    Calculate these dates yourself and pass them directly as arguments.
 
     ## Phase 5 - Database-level detail
     Cycle through the list of databases from Phase 1, for each database do the following steps in order:
@@ -306,9 +312,8 @@ dba_databaseHealthAssessment :
     Detailed Technical Analysis:
     * Complete space utilization breakdown across all databases with visual charts
     * Top 10 space-consuming tables with growth trends and utilization percentages
-    * CPU Resource usage heatmaps showing patterns by weekday and hour of day
-    * IO Resource usage heatmaps showing patterns by weekday and hour of day
-    * Memory Resource usage heatmaps showing patterns by weekday and hour of day
+    * CPU Resource usage heatmaps showing all dates in the 30-day period by hour of day (rows = dates, columns = hours 0-23)
+    * IO Resource usage heatmaps showing all dates in the 30-day period by hour of day (rows = dates, columns = hours 0-23)
     * Flow control metrics and user delay analysis with performance bottleneck identification
     * Database and table activity rankings showing most frequently accessed objects
 

--- a/src/teradata_mcp_server/tools/dba/dba_tools.py
+++ b/src/teradata_mcp_server/tools/dba/dba_tools.py
@@ -287,6 +287,10 @@ def handle_dba_resusageSummary(conn: TeradataConnection,
             no_days = int(no_days)
         except (ValueError, TypeError):
             no_days = 30
+        # no_days defines a date range; ignore single-date filter to avoid conflicting constraints
+        if date is not None:
+            logger.debug(f"Tool: handle_dba_resusageSummary: Ignoring date={date} because no_days={no_days} is set")
+            date = None
 
     comment="Total system resource usage summary."
 


### PR DESCRIPTION
## Summary

- Update `dba_databaseHealthAssessment` Phase 2 to use `no_days=30` instead of `date` parameter, with dimension-specific calls (`["LogDate"]` for trend, `["LogDate","hourOfDay"]` for 30-day heatmap)
- Add single-call enforcement on Phases 3/4 (`dba_flowControl`, `dba_userDelay`) with explicit `start_date`/`end_date` calculation guidance
- Add `dba_tableSpace(top_n=10, exclude_system=true)` to Phase 1 for "Top 10 Space-Consuming Tables"
- Fix `dba_resusageSummary` tool: when both `no_days` and `date` are provided, `no_days` takes precedence

## Motivation

PR #256 restructured `dba_databaseHealthAssessment` into a 6-phase plan. Testing revealed three remaining issues:

1. **Date parameter conflict:** Phase 2 referenced a `date` parameter for `dba_resusageSummary`, but the tool now supports `no_days`. LLM agents passed both, and the single-date `WHERE LogDate = 'date'` filter silently overrode the 30-day range, returning only 1 day of data. The tool fix ensures `no_days` clears `date` when both are present.

2. **Heatmap dimension mismatch:** `["dayOfWeek","hourOfDay"]` produced only 7 aggregated rows (one per weekday), losing date-level granularity. Changing to `["LogDate","hourOfDay"]` produces 30 date-specific rows for a complete daily heatmap.

3. **Per-day iteration on range tools:** Without explicit single-call guidance, the LLM agent expanded `dba_flowControl` and `dba_userDelay` into per-day loops (30 calls instead of 1), multiplying token usage by 30x.

4. **Missing table space analysis:** The health assessment lacked disk usage breakdown — a standard DBA diagnostic.

## Changes

**dba_tools.py:**
- `handle_dba_resusageSummary`: When `no_days` is set, clear `date = None` to prevent single-date override

**dba_objects.yml:**
- `dba_databaseHealthAssessment`:
  - Phase 1: Added `dba_tableSpace(top_n=10, exclude_system=true)`
  - Phase 2: Changed to `no_days=30` with dimension-specific calls
  - Phase 3/4: Added "IMPORTANT: This is a single tool call" enforcement
  - Phase 6: Updated dashboard spec for 30-day heatmap format

## Test plan

- [ ] Verify `dba_resusageSummary(no_days=30, date="2026-02-17")` returns 30 days (not 1)
- [ ] Verify `dba_flowControl` and `dba_userDelay` called once each (not per-day)
- [ ] Verify `dba_tableSpace` appears in Phase 1 output
- [ ] Verify heatmap has ~30 date rows (not 7 weekday rows)
- [ ] Execute full prompt end-to-end — verify no tool call retries