### PR TITLE
Restructure base_databaseBusinessDesc prompt to eliminate per-table context loss

### DIFF
--- a/src/teradata_mcp_server/tools/base/base_objects.yml
+++ b/src/teradata_mcp_server/tools/base/base_objects.yml
@@ -223,34 +223,27 @@ base_databaseBusinessDesc:
 
    ## your role will work through the phases
    Perform the phases in order, and do not skip any phase.
-   
-   ## Phase 0 - Get the database name from the user
-   - the database name is {database_name}
 
-   ## Phase 1 - get the list of tables
+   ## Phase 1 - Get the list of tables
+   - The database name is {database_name}
    - Use the `base_tableList` function to get the list of tables in the database.
 
-   ## Phase 2 - describe the tables
-   For each table, you will:
+   ## Phase 2 - Get the DDL for each table
+   For each table from Phase 1:
    - Use the `base_tableDDL` function to get the DDL for the table.
-   - Based *only* on the DDL you just received, describe the table in a business context. **Do not use any other tools or prompts for this description step.**
 
    ## Phase 3 - Describe the database
-   - Describe the database in a business context based on the business descriptions of the tables. 
-   - The description should be a paragraph. 
-
-
-   ## Communication guidelines:
-         - Be concise but informative in your explanations
-         - Clearly indicate which phase the process is currently in
-         - summarize the outcome of the phase before moving to the next phase
+   Using ALL DDL definitions collected in Phase 2:
+   - For each table, describe its business purpose based *only* on its DDL.
+   - Then describe the overall database in a business context based on all table descriptions.
+   - Present the result as the final output.
 
    ## Final output guidelines:
-         - return in markdown
-         - Example:
-         ***Database Name:*** `database_name`
+   - return in markdown
+   - Example:
+   ***Database Name:*** `database_name`
 
-         ***Description:*** `database_description`
+   ***Description:*** `database_description`
   parameters:
     database_name:
       name: database_name


### PR DESCRIPTION
## Summary

- Restructure prompt from 4 phases to 3 by merging the "get database name" phase into Phase 1 and splitting the per-table "get DDL + describe" loop into separate collection (Phase 2) and analysis (Phase 3) phases
- Eliminates per-table inline LLM analysis calls that discarded accumulated context between iterations

## Motivation

The original prompt used a per-table loop where each iteration called `base_tableDDL` followed by an inline LLM analysis step to describe the table. Each analysis started with fresh context, losing descriptions generated for previous tables. This caused the LLM to re-discover table relationships on every iteration, producing inconsistent cross-table references and unnecessary retries.

Separating DDL collection (tool-only loop) from analysis (single LLM pass over all accumulated DDL) preserves full context and produces a coherent database description in one generation pass.

## Changes

**base_objects.yml:**
- `base_databaseBusinessDesc`: Restructured from 4 phases to 3:
  - Phase 1: Get database name (merged from old Phase 0) + `base_tableList`
  - Phase 2: Loop — collect `base_tableDDL` per table (tool calls only, no LLM analysis)
  - Phase 3: Single LLM pass — describe all tables and database using accumulated DDL context
- Removed redundant "Communication guidelines" section

## Test plan

- [ ] Execute `base_databaseBusinessDesc` prompt end-to-end
- [ ] Verify Phase 2 collects DDL without per-table LLM calls
- [ ] Verify Phase 3 produces coherent database description referencing all tables
- [ ] Verify no tool call retries during execution