### PR TITLE
RequestContext not captured in QueryBand on FastMCP 3.x

### DIFF
--- a/src/teradata_mcp_server/app.py
+++ b/src/teradata_mcp_server/app.py
@@ -27,7 +27,6 @@ from typing import Annotated, Any, Optional
 import yaml
 from fastmcp import FastMCP
 from fastmcp.prompts.prompt import Message, TextContent
-from fastmcp.server.dependencies import get_context
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
 
@@ -318,6 +317,7 @@ def create_mcp_app(settings: Settings):
           context for easier debugging.
         """
         tool_name = kwargs.pop("tool_name", getattr(tool, "__name__", "unknown_tool"))
+        request_context = kwargs.pop("_request_context", None)
         tdconn_local = get_tdconn()
 
         if not getattr(tdconn_local, "engine", None):
@@ -334,8 +334,6 @@ def create_mcp_app(settings: Settings):
                 from sqlalchemy import text
 
                 with tdconn_local.engine.connect() as conn:
-                    ctx = get_context()
-                    request_context = ctx.get_state("request_context") if ctx else None
                     qb = build_queryband(
                         application=mcp.name,
                         profile=profile_name,
@@ -359,8 +357,6 @@ def create_mcp_app(settings: Settings):
             else:
                 raw = tdconn_local.engine.raw_connection()
                 try:
-                    ctx = get_context()
-                    request_context = ctx.get_state("request_context") if ctx else None
                     qb = build_queryband(
                         application=mcp.name,
                         profile=profile_name,

--- a/src/teradata_mcp_server/middleware.py
+++ b/src/teradata_mcp_server/middleware.py
@@ -74,7 +74,7 @@ class RequestContextMiddleware(Middleware):
                     ),
                 )
                 if context.fastmcp_context:
-                    await context.fastmcp_context.set_state("request_context", rc)
+                    await context.fastmcp_context.set_state("request_context", rc, serializable=False)
                 else:
                     self.logger.warning("No FastMCP context available - RequestContext not stored")
             except Exception as e:
@@ -197,7 +197,7 @@ class RequestContextMiddleware(Middleware):
                 user_id=assume_user,
             )
             if context.fastmcp_context:
-                await context.fastmcp_context.set_state("request_context", rc)
+                await context.fastmcp_context.set_state("request_context", rc, serializable=False)
             else:
                 self.logger.warning("No FastMCP context available - RequestContext not stored")
         except Exception as e:

--- a/src/teradata_mcp_server/tools/utils/factory.py
+++ b/src/teradata_mcp_server/tools/utils/factory.py
@@ -2,6 +2,17 @@ import asyncio
 import inspect
 
 
+async def _fetch_request_context():
+    """Fetch RequestContext from FastMCP state in the async layer before thread dispatch."""
+    try:
+        from fastmcp.server.dependencies import get_context
+
+        ctx = get_context()
+        return await ctx.get_state("request_context")
+    except Exception:
+        return None
+
+
 def create_mcp_tool(
     *,
     executor_func=None,
@@ -48,12 +59,14 @@ def create_mcp_tool(
             missing = [n for n in required_params if n not in kwargs]
             if missing:
                 raise ValueError(f"Missing required parameters: {missing}")
-            merged_kwargs = {**inject_kwargs, **kwargs}
+            request_context = await _fetch_request_context()
+            merged_kwargs = {**inject_kwargs, **kwargs, "_request_context": request_context}
             return await asyncio.to_thread(executor_func, **merged_kwargs)
     else:
 
         async def _mcp_tool(**kwargs):
-            merged_kwargs = {**inject_kwargs, **kwargs}
+            request_context = await _fetch_request_context()
+            merged_kwargs = {**inject_kwargs, **kwargs, "_request_context": request_context}
             return await asyncio.to_thread(executor_func, **merged_kwargs)
 
     _mcp_tool.__name__ = tool_name


### PR DESCRIPTION
When the dependency was upgraded from FastMCP 2.x to 3.x, set_state and get_state became async and required JSON-serializable values by default.
  This introduced two silent bugs that caused request_context to always be None (or an unawaited coroutine) when building the Teradata QueryBand, so no per-request fields (REQUEST_ID, SESSION_ID, TENANT, etc.) were ever set.

  Bug 1 — serialization failure (middleware.py):
  set_state was called with serializable=True (default), but RequestContext is a plain Python dataclass, not JSON-serializable. FastMCP raised a TypeError that was silently swallowed by the except-at-debug-level block, so the state was never stored. Fixed by passing serializable=False to both set_state calls, routing the value into the request-scoped in-memory dict (_request_state) instead of the persistent store.

  Bug 2 — async/thread boundary (factory.py, app.py):
  execute_db_tool is a sync function dispatched via asyncio.to_thread. From
  inside a worker thread, calling the async get_state without await returns a coroutine object rather than the actual value. Fixed by capturing request_context in the async _mcp_tool (before thread dispatch) using a
  new _fetch_request_context() helper that properly awaits get_state, then injecting it as _request_context into the executor kwargs. execute_db_tool now pops _request_context from kwargs directly instead of calling get_context()/get_state() from the thread. The now-unused get_context import is removed from app.py.