### PR TITLE
fix: format_text_response serialises dict/list responses as JSON

### DIFF
--- a/src/teradata_mcp_server/utils.py
+++ b/src/teradata_mcp_server/utils.py
@@ -166,6 +166,8 @@ def format_text_response(text: Any):
             return [types.TextContent(type="text", text=json.dumps(parsed, indent=2, ensure_ascii=False))]
         except json.JSONDecodeError:
             return [types.TextContent(type="text", text=str(text))]
+    if isinstance(text, (dict, list)):
+        return [types.TextContent(type="text", text=json.dumps(text, indent=2, ensure_ascii=False, default=str))]
     return [types.TextContent(type="text", text=str(text))]
 
 


### PR DESCRIPTION
## Summary

- `create_response()` was changed in v1.1.0 to return a `dict` instead of a JSON string, but `format_text_response()` in `utils.py` was not updated to handle non-string inputs
- The fallback `str(text)` on a dict produces Python's single-quoted representation (e.g. `{'status': 'success', ...}`), which is not valid JSON
- This caused `json.loads()` to fail in all MCP clients/test runners, making every tool call appear to fail despite the underlying queries succeeding
- Fix adds a `dict`/`list` branch that uses `json.dumps()` so all tool responses are valid JSON

## Test plan

- [x] Run `uv run python tests/run_mcp_tests.py "uv run teradata-mcp-server"` — all 68 tests now pass (previously 0/68)