### PR TITLE
feat: add row-cap on tool outputs (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ We are providing groupings of tools and associated helpful prompts to support al
   - [Plot Tools](./src/teradata_mcp_server/tools/plot/README.md)
  - **BAR** tools, prompts and resources for database backup and restore operations:
    - [BAR Tools](src/teradata_mcp_server/tools/bar/README.md) integrate AI agents with Teradata DSA (Data Stream Architecture) for comprehensive backup management across multiple storage solutions including disk files, cloud storage (AWS S3, Azure Blob, Google Cloud), and enterprise systems (NetBackup, IBM Spectrum).
+ - **Graph** tools for Directed dependency graph analysis for Teradata object lineage and impact analysis:
+   - [Graph Tools](src/teradata_mcp_server/tools/graph/README.md) to generate and analyze directed dependency graphs for Teradata object lineage and impact analysis, enabling users to visualize and understand complex relationships between database objects.
 
 ## Quick start with Claude Desktop (no installation)
 > Prefer to use other tools? Check out our Quick Starts for [VS Code/Copilot](https://github.com/Teradata/teradata-mcp-server/blob/main/docs/server_guide/QUICK_START_VSCODE.md), [Open WebUI](https://github.com/Teradata/teradata-mcp-server/blob/main/docs/server_guide/QUICK_START_OPEN_WEBUI.md), or dive into [simple code examples](https://github.com/Teradata/teradata-mcp-server/blob/main/examples/README.md#client-applications)!

--- a/docs/client_guide/CLIENT_GUIDE.md
+++ b/docs/client_guide/CLIENT_GUIDE.md
@@ -35,6 +35,37 @@ There are many client options that you can choose from, they each have different
 - [Google Gemini CLI](./Google_Gemini_CLI.md)
 
 
+---------------------------------------------------------------------
+
+## Row caps and the `get_all` escape hatch
+
+Tools that return result sets are capped server-side before rows reach the LLM. Defaults are 1000 rows with a 50000 hard ceiling, both configurable on the server (`DEFAULT_ROW_LIMIT`, `MAX_ROW_LIMIT`). Most clients do not need to do anything — the cap is transparent.
+
+Two things are worth knowing when integrating a client:
+
+**1. Every capped tool exposes a `get_all` parameter.** Set `get_all=true` on a single call to raise the cap to the per-tool ceiling. Use it sparingly — the ceiling exists to protect the context window. Tools that opt out of the cap (single-row results, DDL, plans, charts) do not advertise `get_all`.
+
+**2. Truncated responses include a `metadata.truncation` block.** When a result is trimmed, the response payload looks like:
+
+```json
+{
+  "results": [ ... ],
+  "metadata": {
+    "tool_name": "base_columnDescription",
+    "truncation": {
+      "truncated": true,
+      "rows_returned": 1000,
+      "row_limit": 1000,
+      "hard_ceiling": 50000,
+      "get_all_used": false,
+      "hint": "Result truncated. Refine using parameters [table_name, column_name] to narrow the result, or pass get_all=true to raise the limit to 50000 rows."
+    }
+  }
+}
+```
+
+The `hint` is generated server-side and already names the parameters worth narrowing on (or, for `base_readQuery`, suggests adding `TOP`/`SAMPLE`/`WHERE` to the SQL). Client agents should surface this hint to the LLM so it can either ask the user a narrowing question or retry with `get_all=true`. When `get_all=true` was already used and the ceiling was hit, the hint instructs the LLM to refine further or use `persist=true` and query the volatile table directly.
+
 
 
 

--- a/docs/developer_guide/HOW_TO_ADD_YOUR_FUNCTION.md
+++ b/docs/developer_guide/HOW_TO_ADD_YOUR_FUNCTION.md
@@ -94,12 +94,39 @@ You do not need to write a wrapper or call decorators. At startup, the server:
   - Injects a DB connection (`Connection`) as `conn`
   - Optionally injects `fs_config` if your handler declares it
   - Removes internal params (`conn`, `tool_name`, `fs_config`) from the MCP signature
+  - Injects a universal `get_all` parameter (see [Row caps](#row-caps) below) unless the tool opts out
   - Calls the internal `execute_db_tool` which handles:
     - QueryBand (using request context)
     - Error handling + response formatting
     - Reconnect logic if needed
 
 Therefore, handlers should be protocol‑agnostic and not import MCP.
+
+---
+
+### Row caps
+
+Tool result sets are capped before they reach the LLM (defaults: 1000 rows, 50000 ceiling — configurable via `DEFAULT_ROW_LIMIT` / `MAX_ROW_LIMIT`). For most tools you do not need to do anything: handlers that go through `handle_base_readQuery` are capped automatically by `SELECT TOP N+1` injection, and a wrapper-level fallback trims oversized list results from any other handler.
+
+**Customize the cap from YAML.** In your `*_objects.yml`, alongside `parameters:` / `sql:`, set any of:
+
+```yaml
+my_tool_listThings:
+  type: tool
+  description: "..."
+  row_limit: 200              # default cap, overrides DEFAULT_ROW_LIMIT
+  max_row_limit: 5000         # ceiling raised by get_all=true, overrides MAX_ROW_LIMIT
+  bypass_row_cap: true        # never cap; do not inject get_all
+  narrowing_parameters:       # surfaced in the truncation hint
+    - user_name
+    - no_days
+```
+
+Use `bypass_row_cap: true` on tools that already return a single row, return non-list payloads (e.g. DDL, plans, charts), or have their own paging contract. The `narrowing_parameters` list is shown to the client when truncation fires, so the LLM knows which inputs would shrink the result set.
+
+**Reserved kwargs.** When the cap is active the wrapper passes `_row_limit`, `_hard_ceiling`, `_get_all_used`, and `_narrowing_params` into your handler. If you call `handle_base_readQuery` you can ignore them — it pops them itself. If you implement your own SQL execution path, pop them off `kwargs` before binding parameters and either honour the cap yourself or rely on the wrapper-level trim. Do **not** declare a parameter named `get_all` — the wrapper owns that name.
+
+When truncation fires, attach `metadata["truncation"] = build_truncation_metadata(...)` (from `teradata_mcp_server.tools.utils.row_cap`) so the client sees a uniform shape across tools.
 
 ---
 

--- a/docs/server_guide/CONFIGURATION.md
+++ b/docs/server_guide/CONFIGURATION.md
@@ -42,6 +42,10 @@ export AUTH_MODE="none"                # or "basic"
 export AUTH_CACHE_TTL="300"            # seconds
 export AUTH_RATE_LIMIT_ATTEMPTS="5"
 export AUTH_RATE_LIMIT_WINDOW="60"
+
+# Optional: Row-cap on tool outputs (see "Row caps on tool outputs" below)
+export DEFAULT_ROW_LIMIT="1000"        # default cap applied to every tool
+export MAX_ROW_LIMIT="50000"           # ceiling reached when get_all=true
 ```
 
 ### Configuration File (.env) - Optional
@@ -226,6 +230,35 @@ Your custom `profiles.yml` will be merged with the built-in profiles, allowing y
 - Override existing profiles
 - Add new profiles
 - Extend built-in profiles with additional tools
+
+## 📏 Row caps on tool outputs
+
+Tools that return result sets are capped before rows reach the LLM, so a stray `SELECT *` does not blow up the context window. Capped tools expose a universal `get_all` parameter the client can set to raise the cap to a hard ceiling for a single call.
+
+### Limits
+
+| Setting | Env var | Default | Purpose |
+|---|---|---|---|
+| Default cap | `DEFAULT_ROW_LIMIT` | `1000` | Rows returned when `get_all` is not set |
+| Hard ceiling | `MAX_ROW_LIMIT` | `50000` | Upper bound when `get_all=true` |
+
+When a result is trimmed, the response includes a `metadata.truncation` block describing what was capped and which parameters the client could narrow on (see the [Client Guide](../client_guide/CLIENT_GUIDE.md#row-caps-and-the-get_all-escape-hatch)).
+
+### Per-profile overrides
+
+Add a `tool_row_limits:` map to any profile in `profiles.yml` to override the default cap for specific Python tools by exact name:
+
+```yaml
+dba:
+  tool:
+    - "dba_*"
+    - "base_*"
+  tool_row_limits:
+    base_tableList: 5000
+    base_columnDescription: 2000
+```
+
+YAML-defined tools should set `row_limit:` directly in their `*_objects.yml` definition instead — see [How to add your function](../developer_guide/HOW_TO_ADD_YOUR_FUNCTION.md#row-caps).
 
 ## 🔍 Progressive Disclosure
 

--- a/src/teradata_mcp_server/app.py
+++ b/src/teradata_mcp_server/app.py
@@ -44,7 +44,18 @@ from teradata_mcp_server.tools.utils import (
 )
 from teradata_mcp_server.tools.utils.factory import create_mcp_tool
 from teradata_mcp_server.tools.utils.queryband import build_queryband
+from teradata_mcp_server.tools.utils.row_cap import (
+    build_truncation_metadata,
+    compute_narrowing_params,
+    is_bypassed,
+    resolve_row_limit,
+)
 from teradata_mcp_server.utils import format_error_response, format_text_response, resolve_type_hint, setup_logging
+
+
+def _normalize_tool_name(name: str) -> str:
+    """Strip ``handle_`` prefix so bypass-list checks compare against MCP-exposed names."""
+    return name[7:] if name.startswith("handle_") else name
 
 
 def create_mcp_app(settings: Settings):
@@ -307,6 +318,37 @@ def create_mcp_app(settings: Settings):
     hostname = socket.gethostname()
     process_id = f"{hostname}:{os.getpid()}"
 
+    # Row-cap (issue #249): YAML metadata and profile overrides are wired in by Commit 8;
+    # for now the closures pull straight from Settings.
+    _yaml_objects: dict[str, dict[str, Any]] = {}
+    profile_tool_row_limits: dict[str, int] = config.get("tool_row_limits", {}) or {}
+
+    def _resolve_cap_for_tool(tool_name: str, *, get_all: bool, tool_callable=None):
+        """Resolve the effective row-cap for a tool call, or None when bypassed."""
+        normalized = _normalize_tool_name(tool_name)
+        yaml_meta = _yaml_objects.get(normalized)
+        if is_bypassed(normalized, yaml_meta=yaml_meta):
+            return None
+        yaml_row_limit = yaml_meta.get("row_limit") if yaml_meta else None
+        yaml_max = yaml_meta.get("max_row_limit") if yaml_meta else None
+        limit, ceiling, get_all_used = resolve_row_limit(
+            normalized,
+            get_all=get_all,
+            settings_default=settings.default_row_limit,
+            settings_max=settings.max_row_limit,
+            yaml_row_limit=yaml_row_limit if isinstance(yaml_row_limit, int) else None,
+            yaml_max_row_limit=yaml_max if isinstance(yaml_max, int) else None,
+            profile_tool_row_limits=profile_tool_row_limits,
+        )
+        sig = None
+        if tool_callable is not None:
+            try:
+                sig = inspect.signature(tool_callable)
+            except (TypeError, ValueError):
+                sig = None
+        narrowing = compute_narrowing_params(sig, yaml_meta=yaml_meta)
+        return limit, ceiling, narrowing, get_all_used, normalized
+
     def execute_db_tool(tool, *args, **kwargs):
         """Execute a handler with a DB connection and MCP concerns.
 
@@ -319,6 +361,17 @@ def create_mcp_app(settings: Settings):
         """
         tool_name = kwargs.pop("tool_name", getattr(tool, "__name__", "unknown_tool"))
         request_context = kwargs.pop("_request_context", None)
+
+        # Row-cap resolution (issue #249). Pop get_all before it reaches the handler.
+        get_all_flag = bool(kwargs.pop("get_all", False))
+        row_cap_info = _resolve_cap_for_tool(tool_name, get_all=get_all_flag, tool_callable=tool)
+        if row_cap_info is not None:
+            cap_limit, cap_ceiling, cap_narrowing, cap_get_all_used, cap_normalized_name = row_cap_info
+            kwargs["_row_limit"] = cap_limit
+            kwargs["_hard_ceiling"] = cap_ceiling
+            kwargs["_get_all_used"] = cap_get_all_used
+            kwargs["_narrowing_params"] = cap_narrowing
+
         tdconn_local = get_tdconn()
 
         if not getattr(tdconn_local, "engine", None):
@@ -381,6 +434,26 @@ def create_mcp_app(settings: Settings):
                     result = tool(raw, *args, **kwargs)
                 finally:
                     raw.close()
+
+            # Wrapper-side row-cap trim fallback (issue #249). Only fires when the
+            # handler did not already stamp metadata.truncation. Guards against
+            # double-truncation while covering tools that bypass handle_base_readQuery.
+            if row_cap_info is not None and isinstance(result, dict):
+                existing_meta = result.get("metadata") or {}
+                if "truncation" not in existing_meta:
+                    results = result.get("results")
+                    if isinstance(results, list) and len(results) > cap_limit:
+                        result["results"] = results[:cap_limit]
+                        meta = result.setdefault("metadata", {})
+                        meta["truncation"] = build_truncation_metadata(
+                            rows_returned=cap_limit,
+                            row_limit=cap_limit,
+                            hard_ceiling=cap_ceiling,
+                            get_all_used=cap_get_all_used,
+                            tool_name=cap_normalized_name,
+                            narrowing_params=cap_narrowing,
+                        )
+
             return format_text_response(result)
         except Exception as e:
             logger.error(
@@ -395,8 +468,12 @@ def create_mcp_app(settings: Settings):
           signature while still injecting them into the underlying handler.
         - Preserves the handler's parameter names and types so MCP clients can
           render friendly forms.
+        - Injects a universal ``get_all`` parameter on capped tools (issue #249).
         """
         sig = inspect.signature(func)
+        if "get_all" in sig.parameters:
+            raise ValueError(f"Tool {func.__name__} declares reserved parameter 'get_all'")
+
         inject_kwargs = {}
         removable = {"conn", "tool_name"}
         if "fs_config" in sig.parameters:
@@ -409,6 +486,22 @@ def create_mcp_app(settings: Settings):
             if name not in removable
             and p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         ]
+
+        # Inject get_all on capped tools so MCP clients can raise the row cap.
+        normalized = _normalize_tool_name(func.__name__)
+        if not is_bypassed(normalized, yaml_meta=_yaml_objects.get(normalized)):
+            params.append(
+                inspect.Parameter(
+                    "get_all",
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    default=False,
+                    annotation=Annotated[
+                        bool,
+                        "If true, raises the row cap to the hard ceiling for this call.",
+                    ],
+                )
+            )
+
         new_sig = sig.replace(parameters=params)
 
         # Create executor function that will be run in thread
@@ -504,6 +597,53 @@ def create_mcp_app(settings: Settings):
 
     # Register code tools via module loader
     module_loader = td.initialize_module_loader(config)
+
+    # Load YAML-defined tools/resources/prompts up-front so make_tool_wrapper can
+    # consult per-tool YAML metadata (issue #249: row-cap bypass, narrowing_parameters)
+    # at registration time, before the Python handle_* tools are wrapped.
+    custom_object_files: list[Any] = [
+        config_dir / file for file in os.listdir(config_dir) if file.endswith("_objects.yml")
+    ]
+    if custom_object_files:
+        logger.info(
+            f"Found {len(custom_object_files)} custom object files in config directory: {[f.name for f in custom_object_files]}"
+        )
+    if module_loader and profile_name:
+        profile_yml_files = module_loader.get_required_yaml_paths()
+        custom_object_files.extend(profile_yml_files)
+        logger.info(f"Loading YAML files for profile '{profile_name}': {len(profile_yml_files)} files")
+    else:
+        tool_yml_resources = []
+        tools_pkg_root = pkg_files("teradata_mcp_server").joinpath("tools")
+        if tools_pkg_root.is_dir():
+            for subpkg in tools_pkg_root.iterdir():
+                if subpkg.is_dir():
+                    for entry in subpkg.iterdir():
+                        if entry.is_file() and entry.name.endswith(".yml"):
+                            tool_yml_resources.append(entry)
+        custom_object_files.extend(tool_yml_resources)
+        logger.info(f"Loading all YAML files (no specific profile): {len(tool_yml_resources)} files")
+
+    custom_objects: dict[str, Any] = {}
+    custom_glossary: dict[str, Any] = {}
+    for file in custom_object_files:
+        try:
+            if hasattr(file, "read_text"):
+                file_text = file.read_text(encoding="utf-8")
+            else:
+                with open(file, encoding="utf-8", errors="replace") as f:
+                    file_text = f.read()
+            loaded = yaml.safe_load(file_text)
+            if loaded:
+                custom_objects.update(loaded)
+        except Exception as e:
+            logger.error(f"Failed to load YAML from {file}: {e}")
+
+    # Populate row-cap YAML lookup with tool definitions only.
+    _yaml_objects.update(
+        {name: meta for name, meta in custom_objects.items() if isinstance(meta, dict) and meta.get("type") == "tool"}
+    )
+
     if module_loader:
         all_functions = module_loader.get_all_functions()
         registered_count = 0
@@ -605,44 +745,8 @@ def create_mcp_app(settings: Settings):
 
             mcp.tool(name=full_func_name, description=doc_string)(func)
 
-    # Load YAML-defined tools/resources/prompts from config directory
-    custom_object_files: list[Any] = [
-        config_dir / file for file in os.listdir(config_dir) if file.endswith("_objects.yml")
-    ]
-    if custom_object_files:
-        logger.info(
-            f"Found {len(custom_object_files)} custom object files in config directory: {[f.name for f in custom_object_files]}"
-        )
-    if module_loader and profile_name:
-        profile_yml_files = module_loader.get_required_yaml_paths()
-        custom_object_files.extend(profile_yml_files)
-        logger.info(f"Loading YAML files for profile '{profile_name}': {len(profile_yml_files)} files")
-    else:
-        tool_yml_resources = []
-        tools_pkg_root = pkg_files("teradata_mcp_server").joinpath("tools")
-        if tools_pkg_root.is_dir():
-            for subpkg in tools_pkg_root.iterdir():
-                if subpkg.is_dir():
-                    for entry in subpkg.iterdir():
-                        if entry.is_file() and entry.name.endswith(".yml"):
-                            tool_yml_resources.append(entry)
-        custom_object_files.extend(tool_yml_resources)
-        logger.info(f"Loading all YAML files (no specific profile): {len(tool_yml_resources)} files")
-
-    custom_objects: dict[str, Any] = {}
-    custom_glossary: dict[str, Any] = {}
-    for file in custom_object_files:
-        try:
-            if hasattr(file, "read_text"):
-                file_text = file.read_text(encoding="utf-8")
-            else:
-                with open(file, encoding="utf-8", errors="replace") as f:
-                    file_text = f.read()
-            loaded = yaml.safe_load(file_text)
-            if loaded:
-                custom_objects.update(loaded)
-        except Exception as e:
-            logger.error(f"Failed to load YAML from {file}: {e}")
+    # YAML-defined tools/resources/prompts (custom_objects, custom_glossary) were loaded
+    # earlier so make_tool_wrapper can consult per-tool YAML metadata at registration time.
 
     # Prompt helpers
     def make_custom_prompt(prompt_name: str, prompt: str, desc: str, parameters: dict | None = None):
@@ -946,6 +1050,20 @@ def create_mcp_app(settings: Settings):
             ),
         ]
 
+        # Universal row-cap escape hatch (issue #249).
+        if not is_bypassed(name, yaml_meta=_yaml_objects.get(name)):
+            cube_params.append(
+                inspect.Parameter(
+                    "get_all",
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=False,
+                    annotation=Annotated[
+                        bool,
+                        "If true, raises the row cap to the hard ceiling for this call.",
+                    ],
+                )
+            )
+
         # Separate required and optional custom parameters
         all_params = cube_params + parameters
         required_params = [p for p in all_params if p.default is inspect.Parameter.empty]
@@ -960,7 +1078,9 @@ def create_mcp_app(settings: Settings):
             logger.debug(f"  {param_name}: annotation={param.annotation}, default={param.default}")
 
         # Create executor function that will be run in thread
-        def executor(dimensions, measures, dim_filters="", meas_filters="", order_by="", top=None, **kwargs):
+        def executor(
+            dimensions, measures, dim_filters="", meas_filters="", order_by="", top=None, get_all=False, **kwargs
+        ):
             # Validate custom parameters
             missing = [n for n in required_custom_params if n not in kwargs]
             if missing:
@@ -978,6 +1098,7 @@ def create_mcp_app(settings: Settings):
                     top=top,
                 ),
                 tool_name=name,
+                get_all=get_all,
                 **kwargs,
             )
 
@@ -1140,6 +1261,11 @@ Returns:
             logger.info(f"[REGISTRY_HANDLER] Starting handler for tool '{tool_name}'")
             logger.info(f"[REGISTRY_HANDLER] Received kwargs: {kwargs}")
 
+            # Pop row-cap reserved kwargs (issue #249) so they don't leak into SQL building.
+            row_cap_get_all_used = kwargs.pop("_get_all_used", False)
+            for _key in ("_row_limit", "_hard_ceiling", "_narrowing_params"):
+                kwargs.pop(_key, None)
+
             # Extract tool parameters (excluding special params)
             # Note: persist is not supported for registry tools
             special_params = {"tool_name"}
@@ -1164,6 +1290,7 @@ Returns:
                 sql,  # SQL string with values already formatted
                 tool_name=tool_name or tool_name,
                 persist=False,  # Registry tools do not support persist
+                get_all=row_cap_get_all_used,  # Propagate row-cap escape hatch (issue #249)
                 # No **kwargs here - values are already in the SQL string
             )
 

--- a/src/teradata_mcp_server/config/__init__.py
+++ b/src/teradata_mcp_server/config/__init__.py
@@ -42,6 +42,10 @@ class Settings:
     # Tools registration and execution method
     progressive_disclosure: bool = False  # Whether to register tools dynamically for MCP access
 
+    # Row-cap on tool outputs (issue #249). Caps result-set size before rows reach the LLM.
+    default_row_limit: int = 1000
+    max_row_limit: int = 50000
+
 
 def settings_from_env() -> Settings:
     """Create Settings from environment variables only.
@@ -66,4 +70,6 @@ def settings_from_env() -> Settings:
         pool_timeout=int(os.getenv("TD_POOL_TIMEOUT", "30")),
         logging_level=os.getenv("LOGGING_LEVEL", "WARNING"),
         progressive_disclosure=os.getenv("PROGRESSIVE_DISCLOSURE", "false").lower() == "true",
+        default_row_limit=int(os.getenv("DEFAULT_ROW_LIMIT", "1000")),
+        max_row_limit=int(os.getenv("MAX_ROW_LIMIT", "50000")),
     )

--- a/src/teradata_mcp_server/config/profiles.yml
+++ b/src/teradata_mcp_server/config/profiles.yml
@@ -64,9 +64,23 @@ llmUser:
 
 graph:
   tool:
-    - ^graph_.*     
+    - ^graph_.*
   prompt:
     - ^graph_.*
   resource:
     - ^graph_edge_contract$
+
+# Optional row-cap overrides (issue #249).
+# Caps every tool's result set at the per-tool value, falling back to
+# DEFAULT_ROW_LIMIT (1000) and MAX_ROW_LIMIT (50000) env vars otherwise.
+# Add a `tool_row_limits:` map under any profile to override Python handle_*
+# tools by exact name. YAML-defined tools should set `row_limit:` in their
+# `*_objects.yml` definition instead.
+#
+# Example:
+#   dba:
+#     tool: [...]
+#     tool_row_limits:
+#       base_tableList: 5000
+#       base_columnDescription: 2000
 

--- a/src/teradata_mcp_server/tools/base/base_objects.yml
+++ b/src/teradata_mcp_server/tools/base/base_objects.yml
@@ -1,3 +1,13 @@
+# Tool definitions for the `base_*` family.
+#
+# Optional row-cap keys (issue #249) accepted alongside `parameters:`/`sql:`:
+#   row_limit: 200              # default cap for this tool, overrides DEFAULT_ROW_LIMIT
+#   max_row_limit: 5000         # ceiling raised by get_all=true, overrides MAX_ROW_LIMIT
+#   bypass_row_cap: true        # never cap this tool, do not inject get_all
+#   narrowing_parameters:       # parameter names mentioned in the truncation hint
+#     - user_name
+#     - no_days
+
 base_databaseList:
   type: tool
   description: "Lists databases in the Teradata System."

--- a/src/teradata_mcp_server/tools/base/base_tools.py
+++ b/src/teradata_mcp_server/tools/base/base_tools.py
@@ -11,6 +11,11 @@ from sqlalchemy.engine import Connection, default
 from teradatasql import TeradataConnection
 
 from teradata_mcp_server.tools.utils import create_response, rows_to_json
+from teradata_mcp_server.tools.utils.row_cap import (
+    build_truncation_metadata,
+    can_inject_top,
+    wrap_with_top,
+)
 
 logger = logging.getLogger("teradata_mcp_server")
 
@@ -31,6 +36,12 @@ def handle_base_readQuery(
       ResponseType: formatted response with query results + metadata
                    (includes 'volatile_table' field in metadata if persist=True)
     """
+    # Pop reserved row-cap kwargs before they reach bindparams() (issue #249).
+    row_limit = kwargs.pop("_row_limit", None)
+    hard_ceiling = kwargs.pop("_hard_ceiling", None)
+    get_all_used = kwargs.pop("_get_all_used", False)
+    narrowing_params = kwargs.pop("_narrowing_params", None) or []
+
     logger.debug(f"Tool: handle_base_readQuery: Args: sql: {sql}, persist: {persist}, args={args!r}, kwargs={kwargs!r}")
 
     # Generate volatile table name if persisting
@@ -54,6 +65,13 @@ def handle_base_readQuery(
     # 1. Build a textual SQL statement
     if not sql:
         return create_response([], {"tool_name": tool_name or "base_readQuery", "error": "No SQL provided"})
+
+    # Row-cap injection (issue #249): wrap with SELECT TOP N+1 when safe.
+    cap_was_injected = False
+    if row_limit is not None and not persist and can_inject_top(sql):
+        sql = wrap_with_top(sql, row_limit + 1)
+        cap_was_injected = True
+
     stmt = text(sql)
 
     # 2. Bind parameters to the statement if provided.
@@ -78,6 +96,17 @@ def handle_base_readQuery(
 
     # 4. Check if this is a SHOW command (DDL extraction)
     is_show_command = sql and sql.strip().upper().startswith("SHOW ")
+
+    # Row-cap overflow detection (issue #249).
+    truncation_fired = False
+    if row_limit is not None and not persist and not is_show_command:
+        if cap_was_injected and len(raw_rows) > row_limit:
+            raw_rows = raw_rows[:row_limit]
+            truncation_fired = True
+        elif not cap_was_injected and len(raw_rows) > row_limit:
+            # Python-side trim fallback for CTEs and other non-injectable SQL.
+            raw_rows = raw_rows[:row_limit]
+            truncation_fired = True
 
     if is_show_command and raw_rows and len(raw_rows[0]) == 1:
         # This is a SHOW command - concatenate all rows into single DDL
@@ -123,6 +152,16 @@ def handle_base_readQuery(
     if is_show_command and "ddl_complete" in locals():
         metadata["ddl_size"] = len(ddl_complete)
         metadata["rows_concatenated"] = len(raw_rows)
+
+    if truncation_fired and row_limit is not None and hard_ceiling is not None:
+        metadata["truncation"] = build_truncation_metadata(
+            rows_returned=len(data),
+            row_limit=row_limit,
+            hard_ceiling=hard_ceiling,
+            get_all_used=get_all_used,
+            tool_name=tool_name or "base_readQuery",
+            narrowing_params=narrowing_params,
+        )
 
     logger.debug(f"Tool: handle_base_readQuery: metadata: {metadata}")
     return create_response(data, metadata)

--- a/src/teradata_mcp_server/tools/context_catalog.py
+++ b/src/teradata_mcp_server/tools/context_catalog.py
@@ -245,9 +245,13 @@ class ContextCatalog:
         if missing:
             return False, f"Missing required parameters: {', '.join(missing)}"
 
-        # Check for unexpected parameters
+        # Check for unexpected parameters. Universal reserved kwargs (e.g. get_all
+        # from issue #249's row-cap escape hatch) are accepted on every tool.
+        reserved_universal = {"get_all"}
         unexpected = []
         for param_name in kwargs:
+            if param_name in reserved_universal:
+                continue
             if param_name not in metadata.parameters:
                 unexpected.append(param_name)
 

--- a/src/teradata_mcp_server/tools/utils/row_cap.py
+++ b/src/teradata_mcp_server/tools/utils/row_cap.py
@@ -1,0 +1,301 @@
+"""Row-cap helpers for tool outputs (issue #249).
+
+The wrapper layer caps result-set size before rows reach the LLM. This module
+houses the pure logic so it can be unit-tested without the FastMCP runtime.
+
+Resolution order (highest precedence first):
+    1. YAML ``bypass_row_cap: true``        -> no cap (handled by ``is_bypassed``)
+    2. Hard-coded bypass list               -> no cap (handled by ``is_bypassed``)
+    3. YAML ``row_limit:`` (YAML tools)
+    4. ``profiles.yml`` ``tool_row_limits.<tool_name>`` (Python ``handle_*``)
+    5. ``Settings.default_row_limit``
+
+Ceiling: YAML ``max_row_limit:`` if present, else ``Settings.max_row_limit``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from typing import Any
+
+# Tool families that should never receive a row-cap. These either don't return
+# tabular result sets, materialize their own contracts, or have curated SQL.
+DEFAULT_BYPASS_PREFIXES: tuple[str, ...] = (
+    "plot_",
+    "fs_",
+    "tdvs_",
+    "bar_",
+    "rag_",
+    "sql_opt_",
+    "chat_",
+    "tmpl_",
+    "tdml_",
+    "graph_",
+)
+
+DEFAULT_BYPASS_NAMES: frozenset[str] = frozenset(
+    {
+        "base_columnMetadata",  # has its own object-level pagination contract
+        "base_tableDDL",  # single-row DDL
+        "base_saveDDL",  # writes to disk
+        "base_writeQuery",  # DDL/DML
+        "base_dynamicQuery",  # DDL/DML
+    }
+)
+
+# Parameters that are *never* useful for narrowing a result set. Excluded
+# from the dynamic hint that suggests refinement parameters to the LLM.
+NEVER_NARROWING: frozenset[str] = frozenset(
+    {
+        "persist",
+        "output_table_name",
+        "database_name",
+        "format",
+        "max_workers",
+        "max_payload_kb",
+        "max_execution_seconds",
+        "fields",
+        "exclude_objects",
+        "tool_name",
+        "get_all",
+        "conn",
+        "fs_config",
+    }
+)
+
+_LOCKING_PREFIX_RE = re.compile(
+    r"^\s*(?:LOCKING\s+(?:ROW|TABLE)\s+FOR\s+ACCESS\s*)+",
+    re.IGNORECASE,
+)
+
+
+def is_bypassed(tool_name: str, yaml_meta: dict[str, Any] | None = None) -> bool:
+    """Return True when this tool should not receive a row-cap."""
+    if yaml_meta and yaml_meta.get("bypass_row_cap") is True:
+        return True
+    if tool_name in DEFAULT_BYPASS_NAMES:
+        return True
+    return any(tool_name.startswith(prefix) for prefix in DEFAULT_BYPASS_PREFIXES)
+
+
+def resolve_row_limit(
+    tool_name: str,
+    *,
+    get_all: bool,
+    settings_default: int,
+    settings_max: int,
+    yaml_row_limit: int | None = None,
+    yaml_max_row_limit: int | None = None,
+    profile_tool_row_limits: dict[str, int] | None = None,
+) -> tuple[int, int, bool]:
+    """Resolve the effective row-cap for a tool call.
+
+    Returns ``(limit, ceiling, get_all_used)`` where ``limit`` is the
+    effective row count cap and ``ceiling`` is the hard upper bound that
+    ``get_all=True`` would raise toward.
+    """
+    ceiling = yaml_max_row_limit if yaml_max_row_limit is not None else settings_max
+
+    base_limit: int
+    if yaml_row_limit is not None:
+        base_limit = yaml_row_limit
+    elif profile_tool_row_limits and tool_name in profile_tool_row_limits:
+        base_limit = profile_tool_row_limits[tool_name]
+    else:
+        base_limit = settings_default
+
+    if get_all:
+        return ceiling, ceiling, True
+    return min(base_limit, ceiling), ceiling, False
+
+
+# Matches the ``SELECT [DISTINCT|ALL]`` head of a SQL statement. Group 1 is the
+# whole prefix (including any DISTINCT/ALL keyword and trailing whitespace).
+_SELECT_HEAD_RE = re.compile(r"^(SELECT(?:\s+(?:DISTINCT|ALL))?\s+)", re.IGNORECASE)
+# Matches an existing ``TOP n`` immediately after SELECT.
+_EXISTING_TOP_RE = re.compile(r"^TOP\s+\d", re.IGNORECASE)
+
+
+def _strip_for_analysis(sql: str) -> str:
+    """Lift ``LOCKING ... FOR ACCESS`` prefix, strip trailing semicolons/whitespace."""
+    stripped = _LOCKING_PREFIX_RE.sub("", sql).strip()
+    while stripped.endswith(";"):
+        stripped = stripped[:-1].rstrip()
+    return stripped
+
+
+def _has_top_level_keyword(sql: str, keyword: str) -> bool:
+    """Return True when ``keyword`` (uppercase, word-boundaried) appears at paren depth 0."""
+    keyword_upper = keyword.upper()
+    klen = len(keyword_upper)
+    depth = 0
+    upper = sql.upper()
+    n = len(upper)
+    i = 0
+    while i < n:
+        ch = upper[i]
+        if ch == "(":
+            depth += 1
+            i += 1
+            continue
+        if ch == ")":
+            depth -= 1
+            i += 1
+            continue
+        if depth == 0 and upper[i : i + klen] == keyword_upper:
+            before_ok = i == 0 or not (upper[i - 1].isalnum() or upper[i - 1] == "_")
+            after = i + klen
+            after_ok = after >= n or not (upper[after].isalnum() or upper[after] == "_")
+            if before_ok and after_ok:
+                return True
+        i += 1
+    return False
+
+
+def can_inject_top(sql: str | None) -> bool:
+    """Return True when ``TOP n`` can be safely inserted after the SELECT keyword.
+
+    Teradata-specific constraints (errors 3706, 6916) that force a Python-side
+    trim fallback instead:
+      - SHOW commands and CTEs (``WITH ...``)
+      - Statements that already specify ``TOP n``
+      - ``TOP N select requires a FROM clause`` — skip when no top-level FROM
+      - ``Top N option is not supported with QUALIFY clause`` — skip when top-level QUALIFY
+    """
+    if not sql:
+        return False
+    stripped = _strip_for_analysis(sql)
+    if not stripped:
+        return False
+
+    head = stripped[:6].upper()
+    if head.startswith("SHOW "):
+        return False
+    if stripped[:5].upper() == "WITH ":
+        return False
+    if not head.startswith("SELECT"):
+        return False
+
+    select_match = _SELECT_HEAD_RE.match(stripped)
+    if not select_match:
+        return False
+    rest = stripped[select_match.end() :]
+    if _EXISTING_TOP_RE.match(rest):
+        return False
+
+    if not _has_top_level_keyword(stripped, "FROM"):
+        return False
+    return not _has_top_level_keyword(stripped, "QUALIFY")
+
+
+def wrap_with_top(sql: str, n: int) -> str:
+    """Inject ``TOP n`` after the leading ``SELECT`` (and optional DISTINCT/ALL).
+
+    Inline injection avoids derived-table restrictions (Teradata 3706: ORDER BY
+    in subqueries, all expressions must have explicit names). The leading
+    ``LOCKING ... FOR ACCESS`` prefix is preserved at the start. Trailing
+    semicolons are stripped. Caller is responsible for passing ``row_limit + 1``
+    when sentinel detection is desired.
+
+    Falls back to returning the cleaned SQL unchanged when no SELECT head is
+    found (caller should have gated on ``can_inject_top``).
+    """
+    locking_match = _LOCKING_PREFIX_RE.match(sql)
+    locking_prefix = ""
+    body = sql
+    if locking_match:
+        locking_prefix = locking_match.group(0).strip() + " "
+        body = sql[locking_match.end() :]
+
+    body = body.strip()
+    while body.endswith(";"):
+        body = body[:-1].rstrip()
+
+    select_match = _SELECT_HEAD_RE.match(body)
+    if not select_match:
+        return locking_prefix + body
+    head = body[: select_match.end()]
+    rest = body[select_match.end() :]
+    return f"{locking_prefix}{head}TOP {n} {rest}"
+
+
+def compute_narrowing_params(
+    signature: inspect.Signature | None,
+    yaml_meta: dict[str, Any] | None = None,
+) -> list[str]:
+    """Identify parameters that meaningfully narrow this tool's result.
+
+    Resolution order:
+        1. YAML ``narrowing_parameters: [...]`` explicit override
+        2. YAML ``parameters:`` map keys (for YAML-defined tools)
+        3. Signature parameter names (for Python ``handle_*`` tools)
+    Names in ``NEVER_NARROWING`` and any ``_``-prefixed reserved names are filtered out.
+    """
+    if yaml_meta and isinstance(yaml_meta.get("narrowing_parameters"), list):
+        return [str(p) for p in yaml_meta["narrowing_parameters"]]
+
+    candidates: list[str] = []
+    if yaml_meta and isinstance(yaml_meta.get("parameters"), dict):
+        candidates = list(yaml_meta["parameters"].keys())
+    elif signature is not None:
+        candidates = [
+            name
+            for name, param in signature.parameters.items()
+            if param.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        ]
+
+    return [name for name in candidates if name not in NEVER_NARROWING and not name.startswith("_")]
+
+
+def build_truncation_metadata(
+    *,
+    rows_returned: int,
+    row_limit: int,
+    hard_ceiling: int,
+    get_all_used: bool,
+    tool_name: str,
+    narrowing_params: list[str],
+) -> dict[str, Any]:
+    """Build the ``metadata.truncation`` block stamped onto truncated responses."""
+    return {
+        "truncated": True,
+        "rows_returned": rows_returned,
+        "row_limit": row_limit,
+        "hard_ceiling": hard_ceiling,
+        "get_all_used": get_all_used,
+        "hint": _build_hint(tool_name, narrowing_params, hard_ceiling, get_all_used),
+    }
+
+
+def _build_hint(
+    tool_name: str,
+    narrowing_params: list[str],
+    hard_ceiling: int,
+    get_all_used: bool,
+) -> str:
+    if get_all_used:
+        return (
+            f"Result still truncated at the hard ceiling of {hard_ceiling} rows. "
+            "Refine the query — get_all cannot raise the limit further. "
+            "For full results, use persist=true and query the volatile table directly."
+        )
+
+    if tool_name == "base_readQuery":
+        return (
+            "Result truncated. Add a TOP, SAMPLE, or WHERE clause to your SQL, "
+            f"or pass get_all=true to raise the limit to {hard_ceiling} rows."
+        )
+
+    if narrowing_params:
+        params_str = ", ".join(narrowing_params)
+        return (
+            f"Result truncated. Refine using parameters [{params_str}] to narrow "
+            f"the result, or pass get_all=true to raise the limit to {hard_ceiling} rows."
+        )
+
+    return f"Result truncated. Pass get_all=true to raise the limit to {hard_ceiling} rows."

--- a/tests/cases/limits_test_cases.json
+++ b/tests/cases/limits_test_cases.json
@@ -1,0 +1,172 @@
+{
+  "test_cases": {
+    "base_readQuery": [
+      {
+        "name": "limits_default_cap_fires",
+        "parameters": {
+          "sql": "SELECT DatabaseName, TableName FROM DBC.TablesV"
+        },
+        "expect": {
+          "truncation_present": true,
+          "row_limit": 1000,
+          "results_count": 1000,
+          "metadata.truncation.get_all_used": false,
+          "metadata.truncation.hint_contains": "get_all=true"
+        }
+      },
+      {
+        "name": "limits_get_all_raises_cap_envelope",
+        "parameters": {
+          "sql": "SELECT DatabaseName, TableName FROM DBC.TablesV",
+          "get_all": true
+        },
+        "expect": {
+          "results_count_max": 50000
+        }
+      },
+      {
+        "name": "limits_explicit_top_does_not_truncate",
+        "parameters": {
+          "sql": "SELECT TOP 50 DatabaseName, TableName FROM DBC.TablesV"
+        },
+        "expect": {
+          "truncation_present": false,
+          "results_count_max": 50,
+          "metadata.truncation_absent": true
+        }
+      },
+      {
+        "name": "limits_with_cte_caps_via_python_fallback",
+        "parameters": {
+          "sql": "WITH t AS (SELECT DatabaseName FROM DBC.TablesV) SELECT * FROM t"
+        },
+        "expect": {
+          "truncation_present": true,
+          "row_limit": 1000,
+          "results_count": 1000
+        }
+      },
+      {
+        "name": "limits_persist_does_not_cap",
+        "parameters": {
+          "sql": "SELECT TOP 20 DatabaseName, TableName FROM DBC.TablesV",
+          "persist": true
+        },
+        "expect": {
+          "truncation_present": false,
+          "metadata.persist": true
+        }
+      },
+      {
+        "name": "limits_show_command_bypasses_injection",
+        "parameters": {
+          "sql": "SHOW TABLE DBC.DBCInfoTbl"
+        },
+        "expect": {
+          "truncation_present": false,
+          "metadata.truncation_absent": true
+        }
+      },
+      {
+        "name": "limits_no_from_clause_bypasses_injection",
+        "parameters": {
+          "sql": "SELECT CURRENT_TIMESTAMP"
+        },
+        "expect": {
+          "truncation_present": false,
+          "results_count": 1
+        }
+      }
+    ],
+    "dba_userSqlList": [
+      {
+        "name": "limits_dba_userSqlList_envelope_only",
+        "parameters": {
+          "user_name": "DBC",
+          "no_days": 30
+        },
+        "expect": {
+          "results_count_max": 1000
+        }
+      }
+    ],
+    "dba_featureUsage": [
+      {
+        "name": "limits_dba_featureUsage_envelope_only",
+        "parameters": {
+          "start_date": "2024-01-01",
+          "end_date": "2030-01-01"
+        },
+        "expect": {
+          "results_count_max": 1000
+        }
+      }
+    ],
+    "base_tableDDL": [
+      {
+        "name": "limits_base_tableDDL_is_bypassed",
+        "parameters": {
+          "table_name": "DBCInfoTbl",
+          "database_name": "DBC"
+        },
+        "expect": {
+          "metadata.truncation_absent": true
+        }
+      }
+    ],
+    "base_columnMetadata": [
+      {
+        "name": "limits_base_columnMetadata_is_bypassed",
+        "parameters": {
+          "db_name": "DBC",
+          "object_name": "DBCInfoTbl"
+        },
+        "expect": {
+          "metadata.truncation_absent": true
+        }
+      }
+    ],
+    "test_lowLimit": [
+      {
+        "name": "yaml_row_limit_overrides_default_to_5",
+        "parameters": {
+          "database_name": "DBC"
+        },
+        "expect": {
+          "truncation_present": true,
+          "row_limit": 5,
+          "results_count": 5,
+          "metadata.truncation.hard_ceiling": 15,
+          "metadata.truncation.get_all_used": false,
+          "metadata.truncation.hint_contains": "database_name"
+        }
+      },
+      {
+        "name": "yaml_max_row_limit_caps_get_all_at_15",
+        "parameters": {
+          "database_name": "DBC",
+          "get_all": true
+        },
+        "expect": {
+          "truncation_present": true,
+          "row_limit": 15,
+          "results_count": 15,
+          "metadata.truncation.hard_ceiling": 15,
+          "metadata.truncation.get_all_used": true
+        }
+      }
+    ],
+    "test_bypassedFixture": [
+      {
+        "name": "yaml_bypass_row_cap_skips_injection",
+        "parameters": {
+          "database_name": "DBC"
+        },
+        "expect": {
+          "metadata.truncation_absent": true,
+          "results_count_min": 16
+        }
+      }
+    ]
+  }
+}

--- a/tests/cases/limits_test_objects.yml
+++ b/tests/cases/limits_test_objects.yml
@@ -1,0 +1,42 @@
+# Row-cap test fixtures (issue #249).
+#
+# Loaded when CONFIG_DIR=tests/cases (set automatically by tests/run_mcp_tests.py
+# when spawning the MCP server). Defines two tools that exercise the per-tool
+# YAML override paths the unit tests cover in isolation:
+#
+#   - test_lowLimit:       row_limit: 5, max_row_limit: 15
+#   - test_bypassedFixture: bypass_row_cap: true
+#
+# Both query DBC.TablesV which always has well over 15 rows, so the cap and
+# ceiling are deterministic to assert against.
+
+test_lowLimit:
+  type: tool
+  description: "Row-cap test fixture. row_limit=5, max_row_limit=15. Lists tables in a database."
+  parameters:
+    database_name:
+      description: "Database to list tables from"
+      type_hint: str
+      default: 'DBC'
+  row_limit: 5
+  max_row_limit: 15
+  narrowing_parameters:
+    - database_name
+  sql: |
+    SELECT DataBaseName, TableName, TableKind, CommentString
+    FROM DBC.TablesV
+    WHERE DataBaseName = :database_name
+
+test_bypassedFixture:
+  type: tool
+  description: "Row-cap test fixture. bypass_row_cap: true — must skip injection and never stamp metadata.truncation."
+  parameters:
+    database_name:
+      description: "Database to list tables from"
+      type_hint: str
+      default: 'DBC'
+  bypass_row_cap: true
+  sql: |
+    SELECT DataBaseName, TableName
+    FROM DBC.TablesV
+    WHERE DataBaseName = :database_name

--- a/tests/run_mcp_tests.py
+++ b/tests/run_mcp_tests.py
@@ -23,6 +23,99 @@ from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
 
+def _resolve_dot_path(obj, path: str):
+    """Resolve a dotted path through nested dicts. Returns ``(found, value)``."""
+    cursor = obj
+    for part in path.split("."):
+        if isinstance(cursor, dict) and part in cursor:
+            cursor = cursor[part]
+        else:
+            return False, None
+    return True, cursor
+
+
+def _check_expectations(expect: dict, results, metadata: dict) -> str | None:
+    """Apply optional ``expect:`` assertions to a test response.
+
+    Returns an error message string when any assertion fails, or None on success.
+    Supported keys:
+      - ``truncation_present``: bool — assert metadata.truncation.truncated matches
+      - ``row_limit``: int — assert metadata.truncation.row_limit equals
+      - ``results_count``: int — exact length of ``results``
+      - ``results_count_max``: int — ``len(results) <= max``
+      - ``results_count_min``: int — ``len(results) >= min``
+      - ``metadata.<dot.path>``: value — equality on a metadata dot-path
+      - ``metadata.<path>_contains``: substring match on a metadata field
+      - ``metadata.<path>_absent``: true — assert key absent
+    """
+    if not isinstance(expect, dict):
+        return None
+
+    # truncation_present
+    if "truncation_present" in expect:
+        want = bool(expect["truncation_present"])
+        truncation = (metadata or {}).get("truncation") or {}
+        actual = bool(truncation.get("truncated", False))
+        if actual is not want:
+            return f"truncation_present: expected {want}, got {actual}"
+
+    if "row_limit" in expect:
+        truncation = (metadata or {}).get("truncation") or {}
+        if truncation.get("row_limit") != expect["row_limit"]:
+            return f"row_limit: expected {expect['row_limit']}, got {truncation.get('row_limit')}"
+
+    if "results_count" in expect and (not isinstance(results, list) or len(results) != expect["results_count"]):
+        length = len(results) if isinstance(results, list) else "non-list"
+        return f"results_count: expected {expect['results_count']}, got {length}"
+
+    if (
+        "results_count_max" in expect
+        and isinstance(results, list)
+        and len(results) > expect["results_count_max"]
+    ):
+        return f"results_count_max: expected ≤ {expect['results_count_max']}, got {len(results)}"
+
+    if "results_count_min" in expect and (
+        not isinstance(results, list) or len(results) < expect["results_count_min"]
+    ):
+        length = len(results) if isinstance(results, list) else "non-list"
+        return f"results_count_min: expected ≥ {expect['results_count_min']}, got {length}"
+
+    for key, want in expect.items():
+        if key in {
+            "truncation_present",
+            "row_limit",
+            "results_count",
+            "results_count_max",
+            "results_count_min",
+        }:
+            continue
+        if not key.startswith("metadata."):
+            continue
+        path = key[len("metadata.") :]
+        if path.endswith("_absent"):
+            real_path = path[: -len("_absent")]
+            found, _ = _resolve_dot_path(metadata, real_path)
+            if found and bool(want):
+                return f"metadata.{real_path}: expected absent, but found"
+            continue
+        if path.endswith("_contains"):
+            real_path = path[: -len("_contains")]
+            found, value = _resolve_dot_path(metadata, real_path)
+            if not found:
+                return f"metadata.{real_path}: expected to contain {want!r}, but path missing"
+            if not isinstance(value, str) or str(want) not in value:
+                return f"metadata.{real_path}: expected substring {want!r}, got {value!r}"
+            continue
+        found, value = _resolve_dot_path(metadata, path)
+        if not found:
+            return f"metadata.{path}: expected {want!r}, but path missing"
+        if value != want:
+            return f"metadata.{path}: expected {want!r}, got {value!r}"
+
+    return None
+
+
 class MCPTestRunner:
     def __init__(self, test_cases_files: list[str] = ["tests/cases/core_test_cases.json"], verbose: bool = False):
         self.test_cases_files = test_cases_files if isinstance(test_cases_files, list) else [test_cases_files]
@@ -100,7 +193,10 @@ class MCPTestRunner:
                 "MCP_TRANSPORT": "stdio",
                 "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
                 # Show server logs during startup for debugging
-                "LOGGING_LEVEL": "INFO" if self.verbose else "WARNING"
+                "LOGGING_LEVEL": "INFO" if self.verbose else "WARNING",
+                # Load row-cap test fixtures from tests/cases (issue #249).
+                # User-provided CONFIG_DIR wins so external test runs aren't disrupted.
+                "CONFIG_DIR": os.environ.get("CONFIG_DIR") or os.path.join(project_root, "tests", "cases"),
             }
 
             server_params = StdioServerParameters(
@@ -285,6 +381,16 @@ class MCPTestRunner:
                         results_length = len(str(results)) if results else 0
                         if results_length == 0 or (isinstance(results, list | dict) and len(results) == 0):
                             has_warning = True
+
+                        # Optional `expect:` assertions (issue #249).
+                        expect = test_case.get("expect")
+                        if expect:
+                            metadata = response_json.get("metadata") or {}
+                            failure = _check_expectations(expect, results, metadata)
+                            if failure:
+                                status = "FAIL"
+                                error_msg = failure
+                                has_warning = False
                     else:
                         status = "FAIL"
                         if isinstance(results, dict) and "error" in results:
@@ -499,7 +605,10 @@ async def main():
 
     # Default to core test cases if no files specified
     if not test_cases_files:
-        test_cases_files = ["tests/cases/core_test_cases.json"]
+        test_cases_files = [
+            "tests/cases/core_test_cases.json",
+            "tests/cases/limits_test_cases.json",
+        ]
 
     runner = MCPTestRunner(test_cases_files, verbose)
 

--- a/tests/unit/test_row_cap.py
+++ b/tests/unit/test_row_cap.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Unit tests for the row-cap helper module (issue #249).
+
+Exhaustive coverage of pure-logic helpers and the test runner's expectation
+engine. No DB, no network. Run with::
+
+    uv run python tests/unit/test_row_cap.py
+
+Each test is a top-level ``test_*`` function. ``main()`` discovers them, runs
+them all, and reports pass/fail. Exit code is non-zero on any failure.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+# Make src/ and tests/ importable when invoked as a script.
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+from run_mcp_tests import _check_expectations, _resolve_dot_path  # noqa: E402
+
+from teradata_mcp_server.tools.utils.row_cap import (  # noqa: E402
+    DEFAULT_BYPASS_NAMES,
+    DEFAULT_BYPASS_PREFIXES,
+    NEVER_NARROWING,
+    _has_top_level_keyword,
+    build_truncation_metadata,
+    can_inject_top,
+    compute_narrowing_params,
+    is_bypassed,
+    resolve_row_limit,
+    wrap_with_top,
+)
+
+# --------------------------------------------------------------------------
+# is_bypassed
+# --------------------------------------------------------------------------
+
+
+def test_is_bypassed_prefixes():
+    for prefix in DEFAULT_BYPASS_PREFIXES:
+        assert is_bypassed(f"{prefix}example") is True, prefix
+    assert is_bypassed("plot_line_chart") is True
+    assert is_bypassed("chat_completeChat") is True
+    assert is_bypassed("tdml_KMeans") is True
+    assert is_bypassed("graph_traceLineage") is True
+
+
+def test_is_bypassed_names():
+    for name in DEFAULT_BYPASS_NAMES:
+        assert is_bypassed(name) is True, name
+    assert is_bypassed("base_columnMetadata") is True
+    assert is_bypassed("base_tableDDL") is True
+    assert is_bypassed("base_writeQuery") is True
+
+
+def test_is_bypassed_capped_tools_are_not_bypassed():
+    assert is_bypassed("base_readQuery") is False
+    assert is_bypassed("base_tableList") is False
+    assert is_bypassed("dba_userSqlList") is False
+    assert is_bypassed("dba_featureUsage") is False
+    assert is_bypassed("sec_userDbPermissions") is False
+    assert is_bypassed("qlty_missingValues") is False
+
+
+def test_is_bypassed_yaml_override_takes_precedence():
+    assert is_bypassed("dba_userSqlList", yaml_meta={"bypass_row_cap": True}) is True
+    # Explicit False should NOT resurrect a hard-coded bypass.
+    assert is_bypassed("base_columnMetadata", yaml_meta={"bypass_row_cap": False}) is True
+    # Empty / None metadata → defer to defaults.
+    assert is_bypassed("dba_userSqlList", yaml_meta=None) is False
+    assert is_bypassed("dba_userSqlList", yaml_meta={}) is False
+
+
+# --------------------------------------------------------------------------
+# resolve_row_limit
+# --------------------------------------------------------------------------
+
+
+def test_resolve_uses_settings_default():
+    limit, ceiling, used = resolve_row_limit("foo", get_all=False, settings_default=1000, settings_max=50000)
+    assert (limit, ceiling, used) == (1000, 50000, False)
+
+
+def test_resolve_get_all_raises_to_ceiling():
+    limit, ceiling, used = resolve_row_limit("foo", get_all=True, settings_default=1000, settings_max=50000)
+    assert (limit, ceiling, used) == (50000, 50000, True)
+
+
+def test_resolve_yaml_row_limit_overrides_default():
+    limit, _, _ = resolve_row_limit("foo", get_all=False, settings_default=1000, settings_max=50000, yaml_row_limit=200)
+    assert limit == 200
+
+
+def test_resolve_yaml_max_overrides_settings_max():
+    limit, ceiling, _ = resolve_row_limit(
+        "foo",
+        get_all=True,
+        settings_default=1000,
+        settings_max=50000,
+        yaml_row_limit=200,
+        yaml_max_row_limit=5000,
+    )
+    assert (limit, ceiling) == (5000, 5000)
+
+
+def test_resolve_profile_map_overrides_settings_default():
+    limit, _, _ = resolve_row_limit(
+        "foo",
+        get_all=False,
+        settings_default=1000,
+        settings_max=50000,
+        profile_tool_row_limits={"foo": 250},
+    )
+    assert limit == 250
+
+
+def test_resolve_yaml_wins_over_profile_map():
+    """YAML row_limit (per-tool) outranks profile-level tool_row_limits."""
+    limit, _, _ = resolve_row_limit(
+        "foo",
+        get_all=False,
+        settings_default=1000,
+        settings_max=50000,
+        yaml_row_limit=10,
+        profile_tool_row_limits={"foo": 250},
+    )
+    assert limit == 10
+
+
+def test_resolve_clamps_yaml_row_limit_to_ceiling():
+    """Even an aggressive YAML row_limit cannot exceed the effective ceiling."""
+    limit, ceiling, _ = resolve_row_limit(
+        "foo",
+        get_all=False,
+        settings_default=1000,
+        settings_max=50000,
+        yaml_row_limit=999_999,
+    )
+    assert limit == ceiling == 50000
+
+
+# --------------------------------------------------------------------------
+# _has_top_level_keyword
+# --------------------------------------------------------------------------
+
+
+def test_top_level_keyword_finds_simple():
+    assert _has_top_level_keyword("SELECT * FROM t", "FROM") is True
+    assert _has_top_level_keyword("SELECT * FROM t", "WHERE") is False
+
+
+def test_top_level_keyword_skips_inside_parens():
+    # Window function: ORDER BY is inside OVER(...).
+    assert _has_top_level_keyword("SELECT ROW_NUMBER() OVER (ORDER BY x) FROM t", "ORDER BY") is False
+    # Subquery: FROM inside parens is at depth>0.
+    assert _has_top_level_keyword("SELECT (SELECT 1 FROM t)", "FROM") is False
+
+
+def test_top_level_keyword_word_boundaries():
+    # QUALIFY_COL contains QUALIFY but is not the keyword.
+    assert _has_top_level_keyword("SELECT a FROM t WHERE QUALIFY_COL = 1", "QUALIFY") is False
+    # MyORDER is not ORDER.
+    assert _has_top_level_keyword("SELECT MyORDER FROM t", "ORDER BY") is False
+
+
+def test_top_level_keyword_case_insensitive():
+    assert _has_top_level_keyword("select a from t qualify ROW_NUMBER() OVER (order by x) <= 5", "QUALIFY") is True
+    assert _has_top_level_keyword("Select * From t Order By x", "ORDER BY") is True
+
+
+# --------------------------------------------------------------------------
+# can_inject_top
+# --------------------------------------------------------------------------
+
+
+def test_can_inject_simple_select():
+    assert can_inject_top("SELECT * FROM t") is True
+    assert can_inject_top("select a, b from t where c=1") is True
+
+
+def test_can_inject_with_order_by_works_inline():
+    """Inline TOP injection is compatible with ORDER BY (unlike the old derived-table wrap)."""
+    assert can_inject_top("SELECT * FROM t ORDER BY x DESC") is True
+
+
+def test_can_inject_with_qualify_skipped():
+    """Teradata 6916: TOP and QUALIFY are mutually exclusive — must skip injection."""
+    assert can_inject_top("SELECT a FROM t QUALIFY ROW_NUMBER() OVER (ORDER BY x) <= 5") is False
+
+
+def test_can_inject_no_from_skipped():
+    """Teradata 3706: 'Top N select requires a FROM clause'."""
+    assert can_inject_top("SELECT CURRENT_TIMESTAMP") is False
+    assert can_inject_top("SELECT 1 + 2") is False
+
+
+def test_can_inject_show_skipped():
+    assert can_inject_top("SHOW TABLE foo") is False
+    assert can_inject_top("show view bar") is False
+
+
+def test_can_inject_cte_skipped():
+    """CTEs disallow ORDER BY in their inner SELECTs and complicate injection — skip."""
+    assert can_inject_top("WITH x AS (SELECT 1 FROM t) SELECT * FROM x") is False
+    assert can_inject_top("with t1 as (select * from t) select * from t1") is False
+
+
+def test_can_inject_existing_top_skipped():
+    assert can_inject_top("SELECT TOP 5 * FROM t") is False
+    assert can_inject_top("SELECT TOP 50 a, b FROM t WHERE c = 1") is False
+    assert can_inject_top("select top 5 * from t") is False
+
+
+def test_can_inject_distinct_with_top_skipped():
+    assert can_inject_top("SELECT DISTINCT TOP 5 a FROM t") is False
+
+
+def test_can_inject_distinct_alone_works():
+    assert can_inject_top("SELECT DISTINCT a FROM t") is True
+
+
+def test_can_inject_locking_prefix_lifted():
+    assert can_inject_top("LOCKING ROW FOR ACCESS SELECT * FROM t") is True
+    assert can_inject_top("LOCKING TABLE FOR ACCESS SELECT * FROM t WHERE x = 1") is True
+    assert can_inject_top("LOCKING ROW FOR ACCESS\nLOCKING TABLE FOR ACCESS\nSELECT * FROM t") is True
+
+
+def test_can_inject_trailing_semicolons_stripped():
+    assert can_inject_top("SELECT * FROM t;") is True
+    assert can_inject_top("SELECT * FROM t;;;") is True
+
+
+def test_can_inject_non_select_skipped():
+    assert can_inject_top("INSERT INTO t VALUES (1)") is False
+    assert can_inject_top("UPDATE t SET a = 1") is False
+    assert can_inject_top("DELETE FROM t") is False
+    assert can_inject_top("CREATE TABLE t (a INT)") is False
+    assert can_inject_top("DROP TABLE t") is False
+
+
+def test_can_inject_empty_skipped():
+    assert can_inject_top("") is False
+    assert can_inject_top(None) is False
+    assert can_inject_top("   \n  \t  ") is False
+    assert can_inject_top(";") is False
+
+
+# --------------------------------------------------------------------------
+# wrap_with_top
+# --------------------------------------------------------------------------
+
+
+def test_wrap_inline_injection_simple():
+    assert wrap_with_top("SELECT * FROM t", 1001) == "SELECT TOP 1001 * FROM t"
+
+
+def test_wrap_preserves_order_by():
+    """ORDER BY remains in place — inline injection doesn't move it."""
+    assert wrap_with_top("SELECT * FROM t ORDER BY x DESC", 100) == "SELECT TOP 100 * FROM t ORDER BY x DESC"
+
+
+def test_wrap_distinct_top_after_distinct():
+    """Teradata grammar: SELECT [DISTINCT|ALL] [TOP n] cols. TOP follows DISTINCT."""
+    assert wrap_with_top("SELECT DISTINCT a FROM t", 50) == "SELECT DISTINCT TOP 50 a FROM t"
+    assert wrap_with_top("SELECT ALL a FROM t", 50) == "SELECT ALL TOP 50 a FROM t"
+
+
+def test_wrap_locking_prefix_preserved():
+    sql = "LOCKING ROW FOR ACCESS SELECT * FROM t"
+    assert wrap_with_top(sql, 10) == "LOCKING ROW FOR ACCESS SELECT TOP 10 * FROM t"
+
+
+def test_wrap_locking_prefix_with_order_by():
+    sql = "LOCKING ROW FOR ACCESS SELECT * FROM t ORDER BY x DESC;"
+    assert wrap_with_top(sql, 10) == "LOCKING ROW FOR ACCESS SELECT TOP 10 * FROM t ORDER BY x DESC"
+
+
+def test_wrap_strips_trailing_semicolons():
+    assert wrap_with_top("SELECT * FROM t;", 10) == "SELECT TOP 10 * FROM t"
+    assert wrap_with_top("SELECT * FROM t;;;", 10) == "SELECT TOP 10 * FROM t"
+
+
+def test_wrap_real_dba_userSqlList_shape():
+    """Reproduces the issue-#249 query shape that originally hit Teradata 3706."""
+    sql = (
+        "SELECT t1.QueryID, t1.ProcID, t1.CollectTimeStamp, t1.SqlTextInfo, t2.UserName\n"
+        "FROM DBC.QryLogSqlV t1\n"
+        "JOIN DBC.QryLogV t2 ON t1.QueryID = t2.QueryID\n"
+        "WHERE CAST(t1.CollectTimeStamp AS DATE) >= CURRENT_DATE - 7\n"
+        "ORDER BY t1.CollectTimeStamp DESC;"
+    )
+    wrapped = wrap_with_top(sql, 1001)
+    # TOP injected after SELECT, ORDER BY preserved as-is, no derived table.
+    assert wrapped.startswith("SELECT TOP 1001 t1.QueryID")
+    assert wrapped.rstrip().endswith("ORDER BY t1.CollectTimeStamp DESC")
+    assert "_td_capped" not in wrapped
+
+
+# --------------------------------------------------------------------------
+# compute_narrowing_params
+# --------------------------------------------------------------------------
+
+
+def test_narrowing_yaml_explicit_override_wins():
+    yaml_meta = {"parameters": {"a": {}}, "narrowing_parameters": ["x", "y"]}
+    assert compute_narrowing_params(None, yaml_meta) == ["x", "y"]
+
+
+def test_narrowing_yaml_parameters_fallback():
+    yaml_meta = {"parameters": {"user_name": {}, "no_days": {}}}
+    assert compute_narrowing_params(None, yaml_meta) == ["user_name", "no_days"]
+
+
+def test_narrowing_filters_never_narrowing_from_yaml():
+    yaml_meta = {"parameters": {"persist": {}, "database_name": {}, "user_name": {}}}
+    assert compute_narrowing_params(None, yaml_meta) == ["user_name"]
+
+
+def test_narrowing_signature_fallback():
+    def fake(conn, sql: str = "", persist=False, tool_name=None):
+        pass
+
+    sig = inspect.signature(fake)
+    # conn, persist, tool_name in NEVER_NARROWING — only sql remains.
+    assert compute_narrowing_params(sig) == ["sql"]
+
+
+def test_narrowing_underscore_reserved_filtered():
+    """Reserved kwargs prefixed with _ never appear in user-facing hints."""
+
+    def fake(conn, user_name: str = "", _row_limit=None, _hard_ceiling=None):
+        pass
+
+    sig = inspect.signature(fake)
+    assert compute_narrowing_params(sig) == ["user_name"]
+
+
+def test_narrowing_empty_inputs():
+    assert compute_narrowing_params(None) == []
+    assert compute_narrowing_params(None, None) == []
+    assert compute_narrowing_params(None, {}) == []
+
+
+def test_narrowing_never_narrowing_set_complete():
+    """NEVER_NARROWING must include every reserved/non-narrowing parameter."""
+    expected = {
+        "persist",
+        "output_table_name",
+        "database_name",
+        "format",
+        "max_workers",
+        "max_payload_kb",
+        "max_execution_seconds",
+        "fields",
+        "exclude_objects",
+        "tool_name",
+        "get_all",
+        "conn",
+        "fs_config",
+    }
+    assert expected.issubset(NEVER_NARROWING)
+
+
+# --------------------------------------------------------------------------
+# build_truncation_metadata
+# --------------------------------------------------------------------------
+
+
+def test_truncation_metadata_shape():
+    md = build_truncation_metadata(
+        rows_returned=1000,
+        row_limit=1000,
+        hard_ceiling=50000,
+        get_all_used=False,
+        tool_name="dba_userSqlList",
+        narrowing_params=["user_name", "no_days"],
+    )
+    assert md["truncated"] is True
+    assert md["rows_returned"] == 1000
+    assert md["row_limit"] == 1000
+    assert md["hard_ceiling"] == 50000
+    assert md["get_all_used"] is False
+    assert "hint" in md and isinstance(md["hint"], str)
+
+
+def test_truncation_hint_mentions_narrowing_params():
+    md = build_truncation_metadata(
+        rows_returned=1000,
+        row_limit=1000,
+        hard_ceiling=50000,
+        get_all_used=False,
+        tool_name="dba_userSqlList",
+        narrowing_params=["user_name", "no_days"],
+    )
+    assert "user_name" in md["hint"]
+    assert "no_days" in md["hint"]
+    assert "get_all=true" in md["hint"]
+
+
+def test_truncation_hint_for_base_readQuery_is_specialised():
+    """base_readQuery has no parameters that narrow — hint must point at SQL fixes."""
+    md = build_truncation_metadata(
+        rows_returned=1000,
+        row_limit=1000,
+        hard_ceiling=50000,
+        get_all_used=False,
+        tool_name="base_readQuery",
+        narrowing_params=[],
+    )
+    assert "TOP" in md["hint"]
+    assert "SAMPLE" in md["hint"]
+    assert "WHERE" in md["hint"]
+
+
+def test_truncation_hint_at_ceiling_recommends_persist():
+    md = build_truncation_metadata(
+        rows_returned=50000,
+        row_limit=50000,
+        hard_ceiling=50000,
+        get_all_used=True,
+        tool_name="dba_userSqlList",
+        narrowing_params=["user_name"],
+    )
+    assert "ceiling" in md["hint"]
+    assert "persist=true" in md["hint"]
+
+
+def test_truncation_hint_no_narrowing_params_fallback():
+    md = build_truncation_metadata(
+        rows_returned=1000,
+        row_limit=1000,
+        hard_ceiling=50000,
+        get_all_used=False,
+        tool_name="some_tool_no_params",
+        narrowing_params=[],
+    )
+    assert "get_all=true" in md["hint"]
+
+
+# --------------------------------------------------------------------------
+# _check_expectations (test runner assertion engine)
+# --------------------------------------------------------------------------
+
+
+def test_resolve_dot_path_basic():
+    obj = {"a": {"b": {"c": 1}}}
+    assert _resolve_dot_path(obj, "a.b.c") == (True, 1)
+    assert _resolve_dot_path(obj, "a.b") == (True, {"c": 1})
+    assert _resolve_dot_path(obj, "a.x") == (False, None)
+    assert _resolve_dot_path(obj, "missing") == (False, None)
+
+
+def test_check_expectations_pass_when_all_match():
+    md = {"truncation": {"truncated": True, "row_limit": 1000, "hint": "pass get_all=true"}}
+    err = _check_expectations({"truncation_present": True, "row_limit": 1000}, [{"x": 1}] * 1000, md)
+    assert err is None
+
+
+def test_check_expectations_truncation_present_mismatch():
+    err = _check_expectations({"truncation_present": True}, [{"x": 1}], {})
+    assert err is not None and "truncation_present" in err
+
+
+def test_check_expectations_row_limit_mismatch():
+    md = {"truncation": {"truncated": True, "row_limit": 500}}
+    err = _check_expectations({"row_limit": 1000}, [], md)
+    assert err is not None and "row_limit" in err
+
+
+def test_check_expectations_results_count_strict():
+    err = _check_expectations({"results_count": 1000}, [{"x": 1}] * 1000, {})
+    assert err is None
+    err = _check_expectations({"results_count": 999}, [{"x": 1}] * 1000, {})
+    assert err is not None and "results_count" in err
+
+
+def test_check_expectations_results_count_max():
+    err = _check_expectations({"results_count_max": 50000}, [{"x": 1}] * 100, {})
+    assert err is None
+    err = _check_expectations({"results_count_max": 10}, [{"x": 1}] * 100, {})
+    assert err is not None and "results_count_max" in err
+
+
+def test_check_expectations_results_count_min():
+    err = _check_expectations({"results_count_min": 50}, [{"x": 1}] * 100, {})
+    assert err is None
+    err = _check_expectations({"results_count_min": 200}, [{"x": 1}] * 100, {})
+    assert err is not None and "results_count_min" in err
+
+
+def test_check_expectations_dot_path_equality():
+    md = {"truncation": {"row_limit": 1000, "get_all_used": True}}
+    err = _check_expectations({"metadata.truncation.row_limit": 1000}, [], md)
+    assert err is None
+    err = _check_expectations({"metadata.truncation.row_limit": 500}, [], md)
+    assert err is not None
+    err = _check_expectations({"metadata.truncation.get_all_used": True}, [], md)
+    assert err is None
+
+
+def test_check_expectations_contains():
+    md = {"truncation": {"hint": "Refine using parameters [user_name, no_days]"}}
+    err = _check_expectations({"metadata.truncation.hint_contains": "user_name"}, [], md)
+    assert err is None
+    err = _check_expectations({"metadata.truncation.hint_contains": "banana"}, [], md)
+    assert err is not None and "banana" in err
+
+
+def test_check_expectations_absent_path():
+    md_clean = {"tool_name": "foo"}
+    err = _check_expectations({"metadata.truncation_absent": True}, [], md_clean)
+    assert err is None
+    md_dirty = {"truncation": {"truncated": True}}
+    err = _check_expectations({"metadata.truncation_absent": True}, [], md_dirty)
+    assert err is not None and "expected absent" in err
+
+
+def test_check_expectations_dot_path_missing_with_value_expectation():
+    md = {}
+    err = _check_expectations({"metadata.truncation.row_limit": 1000}, [], md)
+    assert err is not None and "missing" in err
+
+
+def test_check_expectations_no_expect_block_passes():
+    err = _check_expectations({}, [{"x": 1}] * 100, {})
+    assert err is None
+    err = _check_expectations(None, [{"x": 1}] * 100, {})
+    assert err is None
+
+
+# --------------------------------------------------------------------------
+# Test runner
+# --------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Discover and run every ``test_*`` function in this module."""
+    tests = [(name, fn) for name, fn in sorted(globals().items()) if name.startswith("test_") and callable(fn)]
+    print(f"Running {len(tests)} unit tests for row_cap helpers…")
+    failed: list[tuple[str, str]] = []
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as e:
+            failed.append((name, f"AssertionError: {e}" if str(e) else "AssertionError"))
+            print(f"  ✗ {name}")
+        except Exception as e:  # noqa: BLE001
+            failed.append((name, f"{type(e).__name__}: {e}"))
+            print(f"  ✗ {name}  ({type(e).__name__})")
+        else:
+            print(f"  ✓ {name}")
+
+    print()
+    print(f"Results: {len(tests) - len(failed)}/{len(tests)} passed")
+    if failed:
+        print()
+        print("FAILURES:")
+        for name, msg in failed:
+            print(f"  - {name}: {msg}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds a configurable row-cap on tool outputs to prevent context blow-ups when tools return large result sets. Defaults to 1000 rows (`DEFAULT_ROW_LIMIT`) with a 50000 hard ceiling (`MAX_ROW_LIMIT`); both are env-configurable.
- Per-tool overrides via YAML (`row_limit`, `max_row_limit`, `bypass_row_cap`, `narrowing_parameters`) and per-profile overrides via `tool_row_limits:` in `profiles.yml`. A universal `get_all=true` parameter is injected on every capped tool as an escape hatch up to the ceiling.
- `handle_base_readQuery` wraps injectable SELECTs with `TOP N+1`, with a Python-side trim fallback for CTEs and registry/cube tools. Truncation metadata (`rows_returned`, `row_limit`, `hard_ceiling`, narrowing-parameter hints) is attached to the response so clients can prompt the user to narrow.

## Test plan
- [ ] `uv run ruff check src/` passes
- [ ] `uv run mypy src/` passes
- [ ] `uv run python -m pytest tests/unit/test_row_cap.py` passes
- [ ] `uv run python tests/run_mcp_tests.py "uv run teradata-mcp-server"` passes against a live Teradata instance, including the new `tests/cases/limits_test_cases.json`
- [ ] Manual: confirm `get_all=true` raises the cap to `MAX_ROW_LIMIT` and the truncation metadata appears when results exceed the cap
- [ ] Manual: verify a YAML tool with `bypass_row_cap: true` is not capped and does not expose `get_all`