### PR TITLE
docs: document base_readQuery row cap and row limit env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Settings dataclass in `config/__init__.py` merges CLI args, environment variable
 
 Tool handlers receive either a SQLAlchemy `Connection` or raw `TeradataConnection` as their first parameter — the wrapper in `app.py` handles injection.
 
+`base_readQuery` caps result rows to prevent LLM token overflow: default 1000 rows, hard ceiling 50000. Configurable via `DEFAULT_ROW_LIMIT` and `MAX_ROW_LIMIT` env vars. When truncated, response metadata includes `truncated: true`; callers can pass a higher `row_limit` or use `persist=true` to bypass the cap.
+
 ### Transport Modes
 
 Set via `MCP_TRANSPORT` env var or `--mcp_transport` flag:

--- a/docs/server_guide/CONFIGURATION.md
+++ b/docs/server_guide/CONFIGURATION.md
@@ -37,6 +37,10 @@ export TD_POOL_SIZE="5"                # connection pool size
 export TD_MAX_OVERFLOW="10"            # max overflow connections
 export TD_POOL_TIMEOUT="30"            # connection timeout seconds
 
+# Optional: Query result limits
+export DEFAULT_ROW_LIMIT="1000"        # default max rows returned by base_readQuery
+export MAX_ROW_LIMIT="50000"           # hard ceiling; callers cannot exceed this
+
 # Optional: Authentication (see Security guide)
 export AUTH_MODE="none"                # or "basic"  
 export AUTH_CACHE_TTL="300"            # seconds
@@ -321,6 +325,19 @@ export TD_POOL_SIZE="5"        # Base connections
 export TD_MAX_OVERFLOW="10"    # Additional connections under load  
 export TD_POOL_TIMEOUT="30"    # Seconds to wait for connection
 ```
+
+### Query Result Limits
+
+`base_readQuery` caps results to prevent LLM token overflow. Results beyond the limit are silently dropped and the response metadata includes `"truncated": true`.
+
+```bash
+export DEFAULT_ROW_LIMIT="1000"   # Default max rows per base_readQuery call
+export MAX_ROW_LIMIT="50000"      # Hard ceiling; the row_limit parameter cannot exceed this
+```
+
+When a query is truncated, the LLM can:
+- Pass a higher `row_limit` (up to `MAX_ROW_LIMIT`) to retrieve more rows in a single response.
+- Pass `persist=true` to write the full result set to a volatile table and query it directly — this bypasses the row cap entirely and is recommended for large result sets.
 
 ### Authentication Methods
 


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_ROW_LIMIT` and `MAX_ROW_LIMIT` to the env vars quick-reference block in `CONFIGURATION.md`
- Adds a new **Query Result Limits** subsection under Database Connection Tuning explaining truncation behaviour, the `row_limit` parameter, and the `persist=true` escape hatch
- Updates `CLAUDE.md` Database Connectivity section with the same context for in-editor guidance

## Related

Follows on from #307 (fix: cap base_readQuery results to prevent LLM token overflow).

## Test plan

- [ ] Verify env var names and defaults match `config/__init__.py` (`DEFAULT_ROW_LIMIT=1000`, `MAX_ROW_LIMIT=50000`)
- [ ] Verify `persist=true` bypass description is accurate against `base_tools.py`