### PR TITLE
bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "teradata-mcp-server"
-version = "0.2.1"
+version = "0.2.2"
 description = "Model Context Protocol (MCP) server for Teradata, Community edition"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bumps package version from `0.2.1` to `0.2.2` in `pyproject.toml`

## Test plan
- [ ] Verify PyPI release publishes with version `0.2.2`