### PR TITLE
Update td_connect.py

### DIFF
--- a/src/teradata_mcp_server/tools/td_connect.py
+++ b/src/teradata_mcp_server/tools/td_connect.py
@@ -115,6 +115,7 @@ class TDConn:
                 pool_size=pool_size,
                 max_overflow=max_overflow,
                 pool_timeout=pool_timeout,
+                pool_pre_ping=True,
             )
             logger.info(f"SQLAlchemy engine created for Teradata: {self._base_host}:{self._base_port}/{self._base_db}")
         except Exception as e:


### PR DESCRIPTION
added "pool_pre_ping=True", this tells SQLAlchemy to issue a lightweight SELECT 1 before returning any connection from the pool. When a transient Teradata instance restarts, stale pooled connections are detected and
   discarded automatically — the next tool call gets a fresh connection and succeeds without the agent or user seeing any error.  Really useful when using Teradata Trial instances.