### PR TITLE
fix: add setup-uv to publish jobs so uvx is available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: test-pypi
     steps:
+      - uses: astral-sh/setup-uv@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: dist
@@ -104,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
+      - uses: astral-sh/setup-uv@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: dist


### PR DESCRIPTION
## Summary

- Fixes `uvx: command not found` error in the `publish-test-pypi` and `publish-pypi` jobs
- The `astral-sh/setup-uv` step was present in the `build` job but missing from the publish jobs, which run on fresh runners with no `uvx` in PATH

## Root cause

Each job in a GitHub Actions workflow runs on a clean runner. The `setup-uv` step from the `build` job does not carry over — each job that calls `uvx` needs its own `setup-uv` step.