### PR TITLE
fix: retry smoke tests to allow PyPI indexing delay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,15 @@ jobs:
 
       - name: Smoke test from TestPyPI
         run: |
-          uvx --no-cache \
-            --index-url https://test.pypi.org/simple \
-            --extra-index-url https://pypi.org/simple \
-            --index-strategy unsafe-best-match \
-            "teradata-mcp-server==${{ needs.build.outputs.version }}" --version
+          for i in 1 2 3 4 5; do
+            uvx --no-cache \
+              --index-url https://test.pypi.org/simple \
+              --extra-index-url https://pypi.org/simple \
+              --index-strategy unsafe-best-match \
+              "teradata-mcp-server==${{ needs.build.outputs.version }}" --version && break
+            echo "Attempt $i failed — waiting 30s for TestPyPI to index the package..."
+            sleep 30
+          done
 
   publish-pypi:
     name: Publish to PyPI
@@ -121,4 +125,8 @@ jobs:
 
       - name: Smoke test from PyPI
         run: |
-          uvx --no-cache "teradata-mcp-server==${{ needs.build.outputs.version }}" --version
+          for i in 1 2 3 4 5; do
+            uvx --no-cache "teradata-mcp-server==${{ needs.build.outputs.version }}" --version && break
+            echo "Attempt $i failed — waiting 30s for PyPI to index the package..."
+            sleep 30
+          done


### PR DESCRIPTION
## Summary

- Fixes smoke test failures caused by PyPI/TestPyPI not yet indexing a freshly uploaded package
- Both smoke test steps now retry up to 5 times with a 30s wait between attempts (max ~2.5 min wait) before failing

## Root cause

PyPI and TestPyPI take 30–120 seconds to make a newly published package available for installation. The smoke test was running immediately after upload and failing with "no version found".