### PR TITLE
feat: add ToolAnnotations to all tool registrations (#317)

### DIFF
--- a/docs/developer_guide/HOW_TO_ADD_YOUR_FUNCTION.md
+++ b/docs/developer_guide/HOW_TO_ADD_YOUR_FUNCTION.md
@@ -86,6 +86,26 @@ fs:
 
 ---
 
+### 🏷️ Tool Annotations (automatic)
+
+Every registered tool receives an MCP `ToolAnnotations` object based on its name prefix. These hints tell LLM clients whether a tool is safe to run silently (`readOnlyHint`) or requires a confirmation prompt (`destructiveHint`).
+
+| Prefix | Hint applied |
+|--------|-------------|
+| `base_`, `dba_`, `sec_`, `rag_`, `qlty_`, `graph_`, `sql_`, `plot_`, `tdvs_` | `readOnlyHint=True, idempotentHint=True` |
+| `bar_` | `readOnlyHint=False, destructiveHint=True` |
+| `tdml_` | `readOnlyHint=False, idempotentHint=True` |
+| `chat_`, `fs_`, unknown prefixes | No annotation (MCP default) |
+
+Per-tool overrides exist for `tdvs_grant_user` and `tdvs_revoke_user` (marked destructive despite the read-only `tdvs_` prefix).
+
+When adding a new tool:
+- **Existing prefix** — no action needed; the correct annotation is inherited automatically.
+- **New prefix** — add an entry to `_PREFIX_ANNOTATIONS` in `app.py`.
+- **Exception within a read-only prefix** (e.g., a future `dba_dropTable`) — add a per-tool entry to `_TOOL_ANNOTATIONS` in `app.py`.
+
+---
+
 ### 🛠️ What the server does for you
 
 You do not need to write a wrapper or call decorators. At startup, the server:

--- a/src/teradata_mcp_server/app.py
+++ b/src/teradata_mcp_server/app.py
@@ -27,6 +27,7 @@ from typing import Annotated, Any, Optional
 import yaml
 from fastmcp import FastMCP
 from fastmcp.prompts.prompt import Message, TextContent
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
 
@@ -47,6 +48,34 @@ from teradata_mcp_server.tools.utils import (
 from teradata_mcp_server.tools.utils.factory import create_mcp_tool
 from teradata_mcp_server.tools.utils.queryband import build_queryband
 from teradata_mcp_server.utils import format_error_response, format_text_response, resolve_type_hint, setup_logging
+
+_TOOL_ANNOTATIONS: dict[str, ToolAnnotations] = {
+    "tdvs_grant_user": ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+    "tdvs_revoke_user": ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+}
+
+_PREFIX_ANNOTATIONS: dict[str, ToolAnnotations] = {
+    "base_":  ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "dba_":   ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "sec_":   ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "rag_":   ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "qlty_":  ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "graph_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "sql_":   ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "plot_":  ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "tdvs_":  ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "bar_":   ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+    "tdml_":  ToolAnnotations(readOnlyHint=False, idempotentHint=True),
+}
+
+
+def _annotations_for(tool_name: str) -> ToolAnnotations | None:
+    if tool_name in _TOOL_ANNOTATIONS:
+        return _TOOL_ANNOTATIONS[tool_name]
+    for prefix, ann in _PREFIX_ANNOTATIONS.items():
+        if tool_name.startswith(prefix):
+            return ann
+    return None
 
 
 def create_mcp_app(settings: Settings):
@@ -565,12 +594,12 @@ def create_mcp_app(settings: Settings):
                 # Always register base_readQuery as a direct MCP tool (core tool)
                 if tool_name == "base_readQuery":
                     wrapped = make_tool_wrapper(func)
-                    mcp.tool(name=tool_name, description=wrapped.__doc__)(wrapped)
+                    mcp.tool(name=tool_name, description=wrapped.__doc__, annotations=_annotations_for(tool_name))(wrapped)
                     logger.info(f"Registered core tool as direct MCP tool: {tool_name}")
             else:
                 # Static mode: register all tools as MCP tools
                 wrapped = make_tool_wrapper(func)
-                mcp.tool(name=tool_name, description=wrapped.__doc__)(wrapped)
+                mcp.tool(name=tool_name, description=wrapped.__doc__, annotations=_annotations_for(tool_name))(wrapped)
                 registered_count += 1
                 logger.debug(f"Registered MCP tool: {tool_name}")
 
@@ -626,7 +655,7 @@ def create_mcp_app(settings: Settings):
             # Register the function as a tool in MCP server.
             func = globals()[full_func_name]
 
-            mcp.tool(name=full_func_name, description=doc_string)(func)
+            mcp.tool(name=full_func_name, description=doc_string, annotations=_annotations_for(full_func_name))(func)
 
     # Load YAML-defined tools/resources/prompts from config directory
     custom_object_files: list[Any] = [
@@ -1051,7 +1080,7 @@ Returns:
             tool_name="get_cube_" + name,
             tool_description=doc_string,
         )
-        return mcp.tool(name=name, description=doc_string)(tool_func)
+        return mcp.tool(name=name, description=doc_string, annotations=_annotations_for(name))(tool_func)
 
     # Register custom objects
     custom_terms: list[tuple[str, Any, str]] = []
@@ -1072,7 +1101,7 @@ Returns:
             else:
                 # Static mode: wrap and register as MCP tool
                 wrapped = make_tool_wrapper(handler)
-                mcp.tool(name=name, description=wrapped.__doc__)(wrapped)
+                mcp.tool(name=name, description=wrapped.__doc__, annotations=_annotations_for(name))(wrapped)
                 logger.info(f"Registered custom YAML tool as MCP tool: {name}")
 
         elif obj_type == "prompt" and any(re.match(pattern, name) for pattern in config.get("prompt", [])):
@@ -1258,7 +1287,7 @@ Returns:
                 else:
                     # Static mode: wrap and register as MCP tool
                     wrapped = make_tool_wrapper(handler)
-                    mcp.tool(name=tool_name, description=wrapped.__doc__)(wrapped)
+                    mcp.tool(name=tool_name, description=wrapped.__doc__, annotations=_annotations_for(tool_name))(wrapped)
                     logger.info(
                         f"[REGISTRY] Registered as MCP tool: {tool_name} (type: {tool_def['object_type']}, object: {tool_def['db_object']}, registered: {tool_def.get('registered_ts')})"
                     )

--- a/tests/verify_tool_annotations.py
+++ b/tests/verify_tool_annotations.py
@@ -1,0 +1,85 @@
+"""Verify that tool registrations include the expected ToolAnnotations.
+
+Runs without a live Teradata connection — list_tools is answered from server
+metadata before any database query is made.
+
+Usage:
+    uv run python tests/verify_tool_annotations.py
+"""
+
+import asyncio
+import os
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Representative sample: one tool per annotation class.
+# Tools from optional modules (bar_, tdml_, tdvs_) are skipped when not loaded.
+EXPECTED: dict[str, dict[str, bool]] = {
+    # read-only + idempotent (base_ prefix)
+    "base_readQuery": {"readOnlyHint": True, "idempotentHint": True},
+    # read-only + idempotent (dba_ prefix — all current tools are SELECT-only)
+    "dba_tableSpace": {"readOnlyHint": True, "idempotentHint": True},
+    # read-only + idempotent (sec_ prefix)
+    "sec_userDbPermissions": {"readOnlyHint": True, "idempotentHint": True},
+    # destructive (bar_ prefix)
+    "bar_manageDsaDiskFileSystem": {"readOnlyHint": False, "destructiveHint": True},
+    # per-tool override: tdvs_ prefix default is read-only, but grant/revoke are destructive
+    "tdvs_grant_user": {"readOnlyHint": False, "destructiveHint": True},
+    "tdvs_revoke_user": {"readOnlyHint": False, "destructiveHint": True},
+    # tdvs_ prefix default still applies to non-grant/revoke tools
+    "tdvs_similarity": {"readOnlyHint": True, "idempotentHint": True},
+    # tdml_ — not read-only but idempotent
+    "tdml_KMeans": {"readOnlyHint": False, "idempotentHint": True},
+}
+
+
+async def main() -> None:
+    env = {**os.environ, "DATABASE_URI": "teradata://dummy:dummy@localhost:1025/dummy"}
+
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "teradata_mcp_server"],
+        env=env,
+    )
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            tools = {t.name: t for t in result.tools}
+
+    failures: list[str] = []
+    skipped: list[str] = []
+
+    for tool_name, expected_hints in EXPECTED.items():
+        if tool_name not in tools:
+            skipped.append(tool_name)
+            continue
+
+        ann = tools[tool_name].annotations
+        for hint, expected_value in expected_hints.items():
+            actual = getattr(ann, hint, None) if ann else None
+            if actual != expected_value:
+                failures.append(
+                    f"  {tool_name}.{hint}: expected {expected_value}, got {actual}"
+                )
+
+    if skipped:
+        print(f"SKIPPED ({len(skipped)} tools not loaded — optional modules):")
+        for name in skipped:
+            print(f"  {name}")
+
+    if failures:
+        print(f"FAIL ({len(failures)} assertion(s)):")
+        for f in failures:
+            print(f)
+        sys.exit(1)
+    else:
+        verified = len(EXPECTED) - len(skipped)
+        print(f"PASS — verified annotations on {verified} tool(s)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -3689,7 +3689,7 @@ wheels = [
 
 [[package]]
 name = "teradata-mcp-server"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Attach MCP ToolAnnotations hints to every registered tool based on name prefix, so LLM clients can distinguish read-only queries from destructive operations without relying on description text.

- Add _PREFIX_ANNOTATIONS and _TOOL_ANNOTATIONS module-level constants in app.py, plus _annotations_for() helper that checks per-tool overrides first then falls back to prefix matching.
- Update all 6 mcp.tool() registration sites (handle_* tools, tdml_* dynamic tools, YAML cube/query tools, registry tools) to pass annotations=_annotations_for(name).
- Annotation map: base_, dba_, sec_, rag_, qlty_, graph_, sql_, plot_, tdvs_ -> readOnlyHint=True/idempotentHint=True; bar_ -> destructiveHint=True; tdml_ -> idempotentHint=True; tdvs_grant_user/tdvs_revoke_user override the read-only tdvs_ default with destructiveHint=True.
- Add tests/verify_tool_annotations.py: standalone script that calls list_tools via MCP client and asserts expected hints — runs without a live Teradata connection.
- Document the prefix-based annotation system in docs/developer_guide/HOW_TO_ADD_YOUR_FUNCTION.md.