### PR TITLE
Add teradata-mcp-customisation skill to agentic/skills/

### DIFF
--- a/agentic/.claude-plugin/plugin.json
+++ b/agentic/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "teradata-mcp-customisation",
+  "description": "Build, edit, and debug a semantic layer for the Teradata MCP server — custom tools, cubes, prompts, and glossary entries declared in YAML, plus the profiles.yml that exposes them.",
+  "version": "1.0.0"
+}

--- a/agentic/skills/teradata-mcp-customisation/SKILL.md
+++ b/agentic/skills/teradata-mcp-customisation/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: teradata-mcp-customisation
+description: Use when the task is to build, edit, or debug a semantic layer for the Teradata MCP server (https://github.com/Teradata/teradata-mcp-server) — custom tools, cubes, prompts, and glossary entries declared in YAML, plus the profiles.yml that exposes them. Covers schema rules, the cube SQL wrapping model, parameter substitution, profile regex selection, and the runtime smoke-test flow.
+---
+
+You are extending the Teradata MCP server with a **semantic layer**: domain-specific tools, cubes, prompts, and glossary terms declared in YAML files that the server picks up at startup.
+
+The server is the upstream project at https://github.com/Teradata/teradata-mcp-server. The customisation surface is documented in `docs/server_guide/CUSTOMIZING.md`; this skill compiles the parts that are easy to get wrong, plus working examples that anyone can run against the `DBC` system database.
+
+## When to use this skill
+
+- Designing a new semantic layer for a Teradata data product (cubes + curated prompts).
+- Adding or editing a custom tool / cube / prompt / glossary entry.
+- Building a `profiles.yml` to expose a subset of objects to a given client.
+- Debugging why a custom object does not appear in `tools/list`, `prompts/list`, or `resources/list`.
+- Migrating a hand-written SQL pattern into a reusable cube the LLM can compose.
+
+## Mental model — what each object becomes at runtime
+
+| YAML `type:` | Where it surfaces | Selected by profile section |
+|---|---|---|
+| `tool` | MCP **tool** — parameterised SQL the LLM calls | `tool:` |
+| `cube` | MCP **tool** — the server auto-generates a 6-arg aggregator (dimensions, measures, dim_filters, meas_filters, order_by, top) plus any custom params you declare | `tool:` |
+| `prompt` | MCP **prompt** — a reusable system / user prompt the client can fetch by name | `prompt:` |
+| `glossary` | MCP **resource** — domain terms surfaced as context resources, enriched with cube measure/dim descriptions | `resource:` |
+
+There is no `type: resource`. Resources are derived: glossary entries become resources, and cube/tool descriptions feed back into glossary enrichment.
+
+## Workflow
+
+1. **Locate the config directory.** The server reads YAML from `--config_dir` (CLI) or `$CONFIG_DIR` (env), defaulting to the current working directory. Drop one or more `*.yml` files there alongside `profiles.yml`. Multiple files merge into one namespace keyed by object name.
+2. **Pick the object type** for what you are building. If in doubt, see `reference/object-types.md`.
+3. **Write the SQL first, in isolation.** Run it in your usual Teradata client until it returns what you want — *then* wrap it as a tool or cube. For cubes, write the flat denormalised base SQL; let the server build the aggregator on top. See `reference/cube-mechanics.md` for exactly how the wrapping works (which is critical for understanding dim_filters vs meas_filters semantics).
+4. **Get parameter substitution right.** Custom tools support two styles: `:param` for value binds, `{param}` for identifier interpolation (database / table names). Cubes also accept custom parameters used inside the base SQL the same way. See `reference/parameter-substitution.md`.
+5. **Expose via `profiles.yml`.** Add a profile (or extend an existing one) with regex selectors. See `reference/profiles.md` for the layering rules and the built-in profiles you can inherit from.
+6. **Smoke-test the server** with the MCP listing flow before pointing a client at it. See `reference/deployment.md` for the bash curl recipe (`initialize` → `notifications/initialized` → `tools/list`).
+
+## Authoring rules (important — don't skip)
+
+1. **Descriptions are the contract.** The `description` fields on tools, cubes, dimensions, measures, and parameters are what the LLM reads to choose and shape its calls. Write them like terse API docs: what it represents, units, when to use it, when *not* to. The server appends type info automatically — don't repeat it.
+2. **Cubes are filtered twice.** `dim_filters` apply to the flat base SQL before aggregation (use raw column names from the base SELECT). `meas_filters` apply after `GROUP BY` (use measure names — `nii > 1000` not `SUM(nii_v) > 1000`). Get this wrong and the LLM will write filters that error or return nothing.
+3. **Pin the domain in the base SQL `WHERE`.** Hard-code the filters that define what the cube *is* (one product family, one subject area). Do not leave that decision to `dim_filters` — the LLM will forget or invent.
+4. **Keep the menu small.** Aim for ~10 dimensions and ~15 measures per cube. More than that and selection accuracy drops sharply. Split into two cubes if you have a wider surface.
+5. **Aggregate measure expressions are first-class.** A measure `expression:` is whatever Teradata SQL evaluates to a scalar over the group — `SUM(...)`, ratios with `NULLIFZERO`, even `SUM(x) OVER ()` for "share of total" measures. The server inlines it as `expression AS measure_name`.
+6. **Never embed credentials** in cube/tool SQL or in `profiles.yml`. Connection strings belong in `profiles.yml`'s `run:` block via env-var substitution (`${TD_USER}`, `${TD_PASSWORD}`), or in the server's own startup env.
+7. **Name with a domain prefix.** `sales_growth_cube`, `dba_space_cube`. A single regex (`sales_.*`) then selects the whole pack into a profile.
+8. **Prompts are not auto-attached.** A `type: prompt` is a callable resource the client *fetches by name* — it is not silently injected into every conversation. Document that in your prompt's `description`.
+
+## Progressive references
+
+Load these only when needed:
+
+- `reference/object-types.md` — full YAML schemas for `tool`, `cube`, `prompt`, `glossary` with every field and what each does.
+- `reference/cube-mechanics.md` — the exact SELECT the server generates around your base SQL, plus the auto-added cube parameters (`dimensions`, `measures`, `dim_filters`, `meas_filters`, `order_by`, `top`).
+- `reference/parameter-substitution.md` — `:name` value binds vs `{name}` identifier formatting, the synthetic `{table_ref}` key, supported `type_hint` values, and the auto-added `persist` parameter on custom tools.
+- `reference/profiles.md` — how `profiles.yml` layers over the packaged profiles, regex selector rules, the `run:` block (transport / port / database URI), and the built-in profiles you can extend (`all`, `eda`, `dba`, `dataScientist`, …).
+- `reference/deployment.md` — `config_dir` resolution, server launch, and the bare-bones curl smoke-test that walks the streamable-HTTP MCP handshake to list tools / prompts / resources.
+
+## Worked examples (DBC-only, portable)
+
+All examples target `DBC` system views so anyone with Teradata access can run them without setting up sample data:
+
+- `examples/example_tool.yml` — a parameterised tool that lists the N largest tables in a given database (`DBC.AllSpaceV`).
+- `examples/example_cube.yml` — a "database space" cube on `DBC.AllSpaceV` with dimensions (database, account, owner) and measures (current_perm, peak_perm, skew_factor).
+- `examples/example_prompt.yml` — a Teradata DBA persona prompt with a `{focus_area}` parameter.
+- `examples/example_glossary.yml` — glossary entries for `permspace`, `spool`, `skew factor`.
+- `examples/example_profiles.yml` — a `dbc_demo` profile that selects the four objects above by regex, plus inherited read-only base tools.
+
+Copy any of these into a `*.yml` file in your config dir, restart the server, and they will appear in the relevant MCP list.

--- a/agentic/skills/teradata-mcp-customisation/examples/example_cube.yml
+++ b/agentic/skills/teradata-mcp-customisation/examples/example_cube.yml
@@ -1,0 +1,95 @@
+# ============================================================================
+# Example cube — "database space" semantic layer over DBC.AllSpaceV
+# ============================================================================
+#
+# Demonstrates:
+#   - flat denormalised base SQL with public-named alias for dimensions and
+#     _v-suffixed alias for measure source columns
+#   - domain pinned in base WHERE (TableName = 'All' for db-level rows,
+#     exclude system schemas the user can't manage)
+#   - aggregate measure expressions, ratio with NULLIFZERO, share-of-total
+#     via SUM(...) OVER ()
+#   - no custom parameters — the auto-added dim_filters / meas_filters /
+#     order_by / top is enough for most ad-hoc questions
+# ============================================================================
+
+dbc_space_cube:
+  type: cube
+  description: |
+    Database-level storage cube. One row per (database, owner, account) with
+    measures derived from DBC.AllSpaceV's database-grain rows (TableName =
+    'All'). Use this for "who is using the space", "which databases are
+    near their cap", "share of total perm" questions. For per-table
+    breakdown within one database, use dbc_top_tables_by_size instead.
+
+    Built-in scope: excludes the DBC, TDWM, and SystemFe administrative
+    schemas, which would otherwise dominate every result.
+  sql: |
+    SELECT
+      s.DataBaseName       AS database_name,
+      d.OwnerName          AS owner_name,
+      d.AccountName        AS account_name,
+      s.CurrentPerm        AS current_perm_v,
+      s.PeakPerm           AS peak_perm_v,
+      s.MaxPerm            AS max_perm_v,
+      s.CurrentSpool       AS current_spool_v,
+      s.PeakSpool          AS peak_spool_v,
+      s.MaxSpool           AS max_spool_v
+    FROM DBC.AllSpaceV s
+    JOIN DBC.DatabasesV d ON d.DatabaseName = s.DataBaseName
+    WHERE s.TableName = 'All'
+      AND s.DataBaseName NOT IN ('DBC', 'TDWM', 'SystemFe')
+  dimensions:
+    database_name:
+      description: "Database / schema name (DBC.AllSpaceV.DataBaseName)."
+      expression: database_name
+    owner_name:
+      description: "Database owner / creator (DBC.DatabasesV.OwnerName)."
+      expression: owner_name
+    account_name:
+      description: "Account string used for workload accounting."
+      expression: account_name
+  measures:
+    current_perm_bytes:
+      description: "Current permanent space in use across all AMPs, bytes."
+      expression: "SUM(current_perm_v)"
+    current_perm_gb:
+      description: "Current permanent space in use, GiB."
+      expression: "CAST(SUM(current_perm_v) / 1073741824.0 AS DECIMAL(18,2))"
+    peak_perm_bytes:
+      description: "Peak permanent space observed since last reset, bytes."
+      expression: "SUM(peak_perm_v)"
+    max_perm_bytes:
+      description: "Maximum permanent space granted to the database, bytes."
+      expression: "SUM(max_perm_v)"
+    perm_utilisation_pct:
+      description: |
+        Current perm as % of granted max. NULL when max=0 (uncapped
+        databases). Above ~85% indicates a database that should be
+        reviewed.
+      expression: "CAST(SUM(current_perm_v) * 100.0 / NULLIFZERO(SUM(max_perm_v)) AS DECIMAL(10,2))"
+    spool_peak_bytes:
+      description: "Peak spool consumed by users charged to this database, bytes."
+      expression: "SUM(peak_spool_v)"
+    share_of_total_perm_pct:
+      description: |
+        This group's share of total CurrentPerm across the result set, %.
+        Useful for ranking which database, owner, or account is using
+        most of the space in scope.
+      expression: "CAST(SUM(current_perm_v) * 100.0 / NULLIFZERO(SUM(SUM(current_perm_v)) OVER ()) AS DECIMAL(10,2))"
+
+# ----------------------------------------------------------------------------
+# Example calls (what the LLM will generate against the auto-built tool):
+#
+#   dimensions    = "database_name"
+#   measures      = "current_perm_gb, perm_utilisation_pct, share_of_total_perm_pct"
+#   dim_filters   = "owner_name = 'DBADMIN'"
+#   meas_filters  = "perm_utilisation_pct > 80"
+#   order_by      = "current_perm_gb DESC"
+#   top           = 20
+#
+# Note:
+#   - dim_filters references owner_name (a column emitted by base SQL).
+#   - meas_filters references perm_utilisation_pct (a measure ALIAS), not
+#     its SUM() expression — see reference/cube-mechanics.md §2.
+# ----------------------------------------------------------------------------

--- a/agentic/skills/teradata-mcp-customisation/examples/example_glossary.yml
+++ b/agentic/skills/teradata-mcp-customisation/examples/example_glossary.yml
@@ -1,0 +1,55 @@
+# ============================================================================
+# Example glossary — Teradata storage / workload terms
+# ============================================================================
+#
+# Demonstrates:
+#   - one glossary object defining many terms
+#   - synonyms list (optional)
+#   - multi-line definitions via YAML block scalar
+#
+# Reminder: glossary objects are selected by the profile's `resource:`
+# pattern list, NOT `tool:`. They surface as MCP resources, not tools.
+# ============================================================================
+
+dbc_glossary:
+  type: glossary
+
+  permspace:
+    definition: |
+      Permanent table storage granted to a database. Measured in bytes per
+      AMP, summed across AMPs in DBC.AllSpaceV. A database's CurrentPerm
+      grows as users insert into its tables; PeakPerm tracks the high-water
+      mark since the counters were last reset.
+    synonyms:
+      - perm
+      - permanent space
+      - currentperm
+
+  spool:
+    definition: |
+      Temporary intermediate storage used by Teradata query execution. Each
+      user / account has a spool quota; running out aborts the query with
+      a 2646 error. Spool is charged to the requesting user, not the
+      database where the data lives.
+    synonyms:
+      - spool space
+      - sortspool
+
+  skew_factor:
+    definition: |
+      Data distribution skew across AMPs, computed as
+      (max_amp_size - avg_amp_size) / max_amp_size * 100. Above ~30%
+      usually indicates a poor primary-index choice that should be
+      reviewed; above ~60% will cause out-of-spool errors on joins.
+    synonyms:
+      - skew
+      - amp skew
+
+  account_string:
+    definition: |
+      A short identifier (DBC.DatabasesV.AccountName) used to group
+      sessions for workload management and accounting. Multiple users can
+      share an account string; charge-back reports aggregate by account.
+    synonyms:
+      - account
+      - account name

--- a/agentic/skills/teradata-mcp-customisation/examples/example_profiles.yml
+++ b/agentic/skills/teradata-mcp-customisation/examples/example_profiles.yml
@@ -1,0 +1,46 @@
+# ============================================================================
+# Example profiles.yml — exposes the dbc_* example objects, plus a "super"
+# profile that adds read-only base tools and qlty for free-form exploration.
+# ============================================================================
+#
+# Demonstrates:
+#   - one profile per audience, named after the persona / use case
+#   - regex selectors with anchored prefix matches
+#   - reuse of the upstream "eda" tool pattern (no writeQuery / dynamicQuery)
+#   - run: block to bind a profile to a specific transport / port
+#   - env-var substitution in the database URI so credentials stay out of
+#     this file
+# ============================================================================
+
+# Curated business profile — only the DBC semantic layer. Suitable for an
+# end-user chat where you want the LLM to call cubes, not write SQL.
+dbc_demo:
+  tool:
+    - ^dbc_top_tables_by_size$
+    - ^dbc_space_cube$
+  prompt:
+    - ^dbc_dba_prompt$
+  resource:
+    - ^dbc_glossary$
+  run:
+    database_uri: "teradata://${TD_USER}:${TD_PASSWORD}@${TD_HOST}:1025"
+    mcp_transport: "streamable-http"
+    mcp_port: 8010
+
+# Super profile — semantic layer + read-only base tools + data-quality
+# tools. Suitable for analysts who want to free-form explore alongside the
+# curated cubes.
+dbc_demo_super:
+  tool:
+    - ^dbc_.*
+    - "base_(?!(writeQuery|dynamicQuery)$).*"
+    - qlty_.*
+    - ^sec_userDbPermissions$
+  prompt:
+    - ^dbc_.*
+  resource:
+    - ^dbc_.*
+  run:
+    database_uri: "teradata://${TD_USER}:${TD_PASSWORD}@${TD_HOST}:1025"
+    mcp_transport: "streamable-http"
+    mcp_port: 8011

--- a/agentic/skills/teradata-mcp-customisation/examples/example_prompt.yml
+++ b/agentic/skills/teradata-mcp-customisation/examples/example_prompt.yml
@@ -1,0 +1,45 @@
+# ============================================================================
+# Example prompt — a DBA persona with a focus_area parameter
+# ============================================================================
+#
+# Demonstrates:
+#   - parameterised prompt with {placeholder} substitution
+#   - required parameter via `required: true` (prompt-specific field)
+#   - description that explicitly tells callers what tools the prompt is
+#     designed to be used alongside
+# ============================================================================
+
+dbc_dba_prompt:
+  type: prompt
+  description: |
+    Teradata DBA persona, scoped to a chosen problem area. Designed to be
+    used with the dbc_top_tables_by_size tool and the dbc_space_cube. The
+    client must fetch this prompt via prompts/get with the focus_area
+    argument set before sending it as the system message.
+  parameters:
+    focus_area:
+      description: |
+        One of 'space', 'workload', or 'security' — controls which kind
+        of question the assistant will treat as in-scope.
+      type_hint: str
+      required: true
+  prompt: |
+    You are a Teradata DBA assistant. Your scope is **{focus_area}**.
+
+    Behaviour:
+    - For in-scope questions, plan before each tool call (one short line),
+      then call the appropriate tool. Reflect on the result before
+      answering.
+    - If the user asks something outside {focus_area}, redirect politely
+      and offer to re-scope.
+    - All sizes in your final answer should be reported in GiB rounded to
+      two decimals. All percentages to one decimal.
+    - Never expose internal column names with the _v suffix or raw SQL.
+
+    Available data:
+    - dbc_space_cube — database / owner / account aggregations of
+      DBC.AllSpaceV. Use this for ranking and "share of total" questions.
+    - dbc_top_tables_by_size — per-table breakdown within one database.
+      Use this when the user names a specific database.
+
+    Glossary terms you may rely on: permspace, spool, skew_factor.

--- a/agentic/skills/teradata-mcp-customisation/examples/example_tool.yml
+++ b/agentic/skills/teradata-mcp-customisation/examples/example_tool.yml
@@ -1,0 +1,41 @@
+# ============================================================================
+# Example custom tool — uses DBC system views so it works on any Teradata
+# system without setup. Lists the N largest tables in a given database by
+# current permanent space.
+# ============================================================================
+#
+# Demonstrates:
+#   - identifier interpolation via {database_name}
+#   - value bind via :n
+#   - parameter defaults (both args optional)
+#   - description fields that surface to the LLM
+# ============================================================================
+
+dbc_top_tables_by_size:
+  type: tool
+  description: |
+    List the top-N largest tables in a Teradata database, ranked by current
+    permanent space (bytes). Reads DBC.AllSpaceV. Use this for quick "what
+    is filling up this schema" questions; for trend / peak analysis use the
+    dbc_space_cube instead.
+  parameters:
+    database_name:
+      description: "Database / schema to inspect. Default DBC (system catalog)."
+      type_hint: str
+      default: "DBC"
+    n:
+      description: "How many tables to return (default 10)."
+      type_hint: int
+      default: 10
+  sql: |
+    SELECT TOP :n
+      TableName                                AS table_name,
+      SUM(CurrentPerm)                         AS current_perm_bytes,
+      SUM(PeakPerm)                            AS peak_perm_bytes,
+      CAST(SUM(CurrentPerm) / 1024.0 / 1024.0
+           AS DECIMAL(18,2))                   AS current_perm_mb
+    FROM DBC.AllSpaceV
+    WHERE DataBaseName = '{database_name}'
+      AND TableName   <> 'All'
+    GROUP BY TableName
+    ORDER BY current_perm_bytes DESC

--- a/agentic/skills/teradata-mcp-customisation/reference/cube-mechanics.md
+++ b/agentic/skills/teradata-mcp-customisation/reference/cube-mechanics.md
@@ -1,0 +1,124 @@
+# How cubes become SQL
+
+When a `type: cube` is loaded, the server registers a single MCP tool whose Python signature is:
+
+```
+my_cube_tool(
+    dimensions: str,         # comma-separated dimension names
+    measures: str,           # comma-separated measure names
+    dim_filters: str,        # raw SQL filter expression, applied PRE-aggregation
+    meas_filters: str,       # raw SQL filter expression, applied POST-aggregation
+    order_by: str,           # raw SQL ORDER BY expression
+    top: int,                # TOP n (0 / empty = no TOP)
+    # ...plus any custom parameters you declared under `parameters:`
+)
+```
+
+The LLM-facing description for each of these args is auto-built from your cube's dimension / measure names — so you only need to write good `description:` strings on each dim and measure.
+
+## The generated SQL
+
+For a call with `dimensions = "d1, d2"`, `measures = "m1, m2"`, the server builds:
+
+```sql
+SELECT TOP {top} * FROM
+(SELECT
+  <expression-of-d1>,
+  <expression-of-d2>,
+  <expression-of-m1> AS m1,
+  <expression-of-m2> AS m2
+FROM (
+  sel * from ( <YOUR BASE SQL, with :params substituted> ) a
+  WHERE <dim_filters>          -- omitted if empty
+) AS c
+GROUP BY d1, d2
+) AS a
+WHERE <meas_filters>            -- omitted if empty
+ORDER BY <order_by>             -- omitted if empty
+;
+```
+
+Three consequences fall out of this shape — internalise them before authoring a cube.
+
+### 1. `dim_filters` runs on **base SQL columns**, not on dimension expressions
+
+The base SQL is wrapped as `sel * from ( ... ) a`, and `dim_filters` lives in the outer `WHERE` of that subquery. So `dim_filters` references **whatever columns your base SELECT emits**.
+
+If your base SQL aliases columns to the same names as your dimensions, `dim_filters` looks symmetric to the LLM:
+```yaml
+dim_filters example:  database_name = 'FINANCE'
+```
+If you don't alias, the LLM will write `dim_filters` against dimension names that don't exist in the inner table, and you'll get a SQL error. **Always alias base columns to the dimension name** unless you have a strong reason not to.
+
+### 2. `meas_filters` runs on **measure aliases**, not on aggregate expressions
+
+After `GROUP BY`, the inner result has columns named after the measures (`m1`, `m2`, …). `meas_filters` is applied as the outer `WHERE`, so:
+```yaml
+meas_filters example:  current_perm_bytes > 1000000000     -- correct
+meas_filters example:  SUM(current_perm_v) > 1000000000    -- WRONG, won't resolve
+```
+
+### 3. Window functions in measures see the **post-aggregation** rowset
+
+Because the `OVER ()` evaluates after `GROUP BY`, you can write share-of-total style measures cleanly:
+
+```yaml
+share_of_total_pct:
+  description: "Group's share of the total across all rows in the result, %."
+  expression: "CAST(SUM(x_v) * 100.0 / NULLIFZERO(SUM(SUM(x_v)) OVER ()) AS DECIMAL(10,2))"
+```
+
+Note the double `SUM` — inner `SUM(x_v)` is the per-group aggregate, outer `SUM(...) OVER ()` is the total across groups.
+
+## Designing the base SQL
+
+A good base SQL is:
+
+- **Flat and denormalised.** Pre-join all the dimension tables. The cube tool should not have to know about joins.
+- **Pinned to a domain.** Hard-code the filters that define what the cube *is* (subject area, view flag, product family). Do not let the LLM pick those via `dim_filters`.
+- **Row-grain matches the smallest dimension you expose.** If your finest dimension is `month_end × business_line`, that's your row grain. Coarser dim selections aggregate cleanly via `GROUP BY`.
+- **Aliased to the public names.** Each base column that becomes a dimension is aliased to the dimension name; each base column that feeds a measure is aliased to a `_v` (value) suffix to signal "internal."
+
+```sql
+SELECT
+  d.database_name      AS database_name,    -- dimension column, public name
+  d.owner_name         AS owner_name,
+  s.current_perm       AS current_perm_v,   -- internal value column
+  s.max_perm           AS max_perm_v
+FROM DBC.AllSpaceV s
+JOIN DBC.DatabasesV d ON s.databasename = d.database_name
+WHERE s.tablename = 'All'                   -- domain pin
+```
+
+## Period-vs-period and other parameterised cubes
+
+If your cube needs runtime parameters (date ranges, currency, snapshot date), declare them under `parameters:` and reference them in the base SQL with `:name` bind syntax:
+
+```yaml
+sql: |
+  SELECT ...
+  FROM fact
+  WHERE event_date BETWEEN :period_start AND :period_end
+```
+
+For comparison cubes (current period vs previous period), a common pattern is to emit period-tagged value columns from the base SQL, then `SUM` each in measures:
+
+```sql
+-- inside base SQL
+CASE WHEN event_date BETWEEN :cstart AND :cend THEN amount END AS amount_cur_v,
+CASE WHEN event_date BETWEEN :pstart AND :pend THEN amount END AS amount_prev_v
+```
+```yaml
+measures:
+  amount_cur:  { expression: "SUM(amount_cur_v)" }
+  amount_prev: { expression: "SUM(amount_prev_v)" }
+  delta:       { expression: "SUM(amount_cur_v) - SUM(amount_prev_v)" }
+```
+
+This lets the LLM compare two arbitrary periods through a single tool call, and the attribution measures (volume effect, rate effect) compose from the same value columns.
+
+## Hard limits and soft guidance
+
+- **No hard cap** on dimensions or measures, but selection quality degrades sharply beyond ~10 dims and ~15 measures. Split into two cubes rather than building a god-cube.
+- **Dimensions and measures share a namespace** in `order_by`. You can order by either by name.
+- **An unknown measure raises an error** (`ValueError: Measure '...' not found in cube '...'`); an unknown dimension is passed through as a raw column reference, which usually fails downstream. Validate both names in your tests.

--- a/agentic/skills/teradata-mcp-customisation/reference/deployment.md
+++ b/agentic/skills/teradata-mcp-customisation/reference/deployment.md
@@ -1,0 +1,111 @@
+# Deploying and smoke-testing your customisation
+
+## Config directory resolution
+
+The server reads YAML from, in order:
+
+1. `--config_dir <path>` CLI arg
+2. `$CONFIG_DIR` env var
+3. Current working directory (fallback)
+
+It picks up **every `*.yml` file** in that directory, in addition to the packaged defaults shipped under `src/teradata_mcp_server/config/`. Your files override packaged objects by name; your `profiles.yml` replaces the packaged one at the top-level key.
+
+Recommended layout:
+
+```
+~/my-mcp-config/
+├── profiles.yml
+├── dbc_objects.yml
+└── domain_objects.yml
+```
+
+## Launching
+
+```bash
+# CLI args
+teradata-mcp-server \
+  --config_dir ~/my-mcp-config \
+  --profile dbc_demo
+
+# Or via env
+export CONFIG_DIR=~/my-mcp-config
+export PROFILE=dbc_demo
+teradata-mcp-server
+```
+
+The database connection follows the standard precedence: `--database_uri` / `$DATABASE_URI` / `run.database_uri` in the active profile. Use env-var substitution (`teradata://${TD_USER}:${TD_PASSWORD}@host:1025`) so credentials never end up in YAML.
+
+## Smoke-test: walk the MCP handshake with curl
+
+The streamable-HTTP transport returns JSON inside SSE frames (`data: …` lines). The shell script below walks `initialize` → `notifications/initialized` → `tools/list` / `prompts/list` / `resources/list`, capturing the `Mcp-Session-Id` header between steps.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-http://localhost:8000/mcp/}"
+H_FILE="$(mktemp)"; trap 'rm -f "$H_FILE"' EXIT
+
+# 1. initialize — grab the session id from response headers
+curl -sS -D "$H_FILE" -o /dev/null "$URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+       "params":{"protocolVersion":"2025-03-26",
+                 "capabilities":{},
+                 "clientInfo":{"name":"smoketest","version":"0"}}}'
+
+SID="$(awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' "$H_FILE" | tr -d '\r')"
+echo "Session: $SID"
+
+# 2. notifications/initialized
+curl -sS -o /dev/null "$URL" \
+  -H "Mcp-Session-Id: $SID" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+
+# 3. list each registry
+for METHOD in tools/list prompts/list resources/list; do
+  echo
+  echo "== $METHOD =="
+  curl -sS "$URL" \
+    -H "Mcp-Session-Id: $SID" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"$METHOD\",\"params\":{}}" \
+    | sed -n 's/^data: //p' \
+    | (command -v jq >/dev/null && jq . || cat)
+done
+```
+
+Save as `mcp_list_tools.sh`, `chmod +x`, run against your server. You should see:
+
+- Your `type: tool` and `type: cube` objects in `tools/list` (cubes carry the 6 auto-added args plus your custom ones).
+- Your `type: prompt` objects in `prompts/list`.
+- Your `type: glossary` entries in `resources/list`.
+
+## Diagnosing missing objects
+
+| Symptom | Likely cause |
+|---|---|
+| Object missing from all lists | YAML failed to parse → check server logs for `Failed to load YAML from …` |
+| Tool present but not in your profile | Regex selector mismatch — `foo_*` is `foo` then zero-or-more underscores; you probably wanted `foo_.*` |
+| Glossary missing | Glossary is selected by `resource:` not `tool:` |
+| Cube tool errors with `ValueError: Measure '…' not found` | Caller passed a measure name that isn't in the cube's `measures:` dict — usually a typo in your prompt or a stale schema cache |
+| `dim_filters` ignored or causing parse errors | You wrote it against dimension names that aren't aliased in the base SQL; or you used post-aggregation column names — use `meas_filters` for those |
+| Identifier interpolation produces `'DBC.AllSpaceV'` literal | You used `:database_name` instead of `{database_name}` for an identifier |
+
+## Where to look in logs
+
+The server logs at startup:
+
+```
+Configuration directory set to: <path>
+Loading all YAML files (no specific profile): N files
+Added custom tool: <name>
+Added custom cube: <name>
+Added custom prompt: <name>
+Added custom glossary entries for: <name>.
+```
+
+If your object name doesn't show up in one of those lines, the file didn't load or the `type:` wasn't recognised.

--- a/agentic/skills/teradata-mcp-customisation/reference/object-types.md
+++ b/agentic/skills/teradata-mcp-customisation/reference/object-types.md
@@ -1,0 +1,188 @@
+# Object types — full YAML schemas
+
+All custom objects live in `*.yml` files in the config directory. Each file is a top-level dictionary keyed by **object name** (must be a regex-friendly identifier; use snake_case with a domain prefix). Multiple files are merged into one namespace.
+
+Every object has a mandatory `type:` field selecting one of the four schemas below.
+
+---
+
+## `type: tool` — parameterised SQL query
+
+A reusable SQL the LLM calls with arguments. The server wraps it through `base_readQuery` (read-only); for writes use the built-in `base_writeQuery`.
+
+```yaml
+my_tool_name:
+  type: tool
+  description: "What this tool does — surfaced to the LLM as the docstring."
+  sql: |
+    SELECT col1, col2
+    FROM {database_name}.{table_name}
+    WHERE event_date >= :start_date
+      AND amount > :min_amount
+    ORDER BY event_date
+  parameters:
+    database_name:
+      description: "Schema containing the target table."
+      type_hint: str
+      default: "DBC"             # makes the parameter optional
+    table_name:
+      description: "Table to query."
+      type_hint: str
+    start_date:
+      description: "Inclusive lower bound, 'YYYY-MM-DD'."
+      type_hint: str
+    min_amount:
+      description: "Filter rows where amount strictly exceeds this."
+      type_hint: float
+      default: 0
+```
+
+**Required:** `type`, `sql`. **Recommended:** `description`, `parameters`.
+
+**Auto-added parameters** (the LLM sees them on every custom tool):
+- `persist: bool = False` — when `True`, materialises the result as a volatile table and returns the table name instead of rows. Useful for chaining tool calls without re-running expensive queries.
+
+**Parameter fields:**
+- `description` — surfaced to the LLM. Always write one.
+- `type_hint` — one of `"str"`, `"int"`, `"float"`, `"bool"`, `"list"`, `"dict"`, `"Any"`. Anything else falls back to `str`. The resolved type is appended to the LLM-facing description as `(type: int)` etc.
+- `default` — presence makes the parameter optional. Absence makes it required.
+
+See `parameter-substitution.md` for the difference between `:name` (value binds) and `{name}` (identifier interpolation, e.g. table/database names that cannot be bound).
+
+---
+
+## `type: cube` — semantic aggregator
+
+A flat base SQL plus a vocabulary of dimensions and measures. The server wraps the base SQL with a filter → GROUP BY → filter SELECT and exposes a single MCP tool whose 6 auto-added parameters drive the wrapping. See `cube-mechanics.md` for the exact generated SQL.
+
+```yaml
+my_cube_name:
+  type: cube
+  description: |
+    What this cube models, what subject area it covers, what filters
+    are baked in. Tell the LLM both when to use it and when NOT to.
+  parameters:
+    period_start:
+      description: "Inclusive lower bound on event_date, 'YYYY-MM-DD'."
+      type_hint: str
+    period_end:
+      description: "Inclusive upper bound on event_date, 'YYYY-MM-DD'."
+      type_hint: str
+  sql: |
+    SELECT
+      d.database_name   AS database_name,
+      d.owner_name      AS owner_name,
+      d.account_name    AS account_name,
+      s.current_perm    AS current_perm_v,
+      s.peak_perm       AS peak_perm_v,
+      s.max_perm        AS max_perm_v
+    FROM DBC.DatabasesV d
+    JOIN DBC.AllSpaceV  s ON s.databasename = d.database_name
+    WHERE s.tablename = 'All'
+      AND d.database_name NOT IN ('DBC', 'TDWM')   -- pin domain
+  dimensions:
+    database_name:
+      description: "Schema / database name (DBC.DatabasesV.database_name)."
+      expression: database_name
+    owner_name:
+      description: "Database owner (creator)."
+      expression: owner_name
+    account_name:
+      description: "Account string used for workload accounting."
+      expression: account_name
+  measures:
+    current_perm_bytes:
+      description: "Permanent space currently in use, bytes."
+      expression: SUM(current_perm_v)
+    peak_perm_bytes:
+      description: "Peak permanent space observed, bytes."
+      expression: MAX(peak_perm_v)
+    utilisation_pct:
+      description: "Current perm as % of granted max. NULL when max=0."
+      expression: "CAST(SUM(current_perm_v) * 100.0 / NULLIFZERO(SUM(max_perm_v)) AS DECIMAL(10,2))"
+    share_of_total_pct:
+      description: "Group's share of total current_perm across the result, %."
+      expression: "CAST(SUM(current_perm_v) * 100.0 / NULLIFZERO(SUM(SUM(current_perm_v)) OVER ()) AS DECIMAL(10,2))"
+```
+
+**Required:** `type`, `sql`, `dimensions`, `measures`. **Recommended:** `description`, `parameters`.
+
+**Conventions that pay off:**
+- In the base SQL, alias dimension source columns to the dimension name (`d.database_name AS database_name`) so the dimension `expression:` is just the bare name. Alias measure source columns with a `_v` suffix (`s.current_perm AS current_perm_v`) to signal "internal value column, not for direct selection."
+- Pin domain filters in the base SQL `WHERE` (e.g. `tablename = 'All'`, exclude system schemas). Do not push that into `dim_filters`.
+- Measure expressions are evaluated *after* the implicit `GROUP BY <dimensions>`. They can be any aggregate, including ratios, `CAST`s, and window expressions like `SUM(x) OVER ()` for share-of-total measures.
+
+---
+
+## `type: prompt` — reusable prompt
+
+A named prompt the client fetches via `prompts/get`. Static text by default; parameterised with Python `str.format`-style placeholders.
+
+```yaml
+my_prompt_name:
+  type: prompt
+  description: "DBA persona that focuses on a chosen problem area."
+  parameters:
+    focus_area:
+      description: "What the DBA should emphasise: 'space', 'workload', or 'security'."
+      type_hint: str
+      required: true
+  prompt: |
+    You are a Teradata DBA assistant. Focus on {focus_area} questions.
+    When the user asks an unrelated question, redirect them politely.
+```
+
+**Required:** `type`, `prompt`. **Recommended:** `description`, `parameters`.
+
+**Parameter fields for prompts** (differ slightly from tools):
+- `description` — surfaced to the client.
+- `type_hint` — same set as tools.
+- `required: bool` — defaults to `true` (note: opposite default from tools, which infer requiredness from presence of `default`).
+- `default` — if present, parameter is optional regardless of `required`.
+
+If `parameters:` is empty or omitted, the prompt is served as-is. With parameters, the server calls `prompt.format(**kwargs)` — so any literal `{` in the prompt body must be doubled `{{` to escape.
+
+---
+
+## `type: glossary` — domain terms (becomes MCP resource)
+
+A single glossary block defines many terms in one object. Selected by the **`resource:`** pattern list in profiles, not `tool:`.
+
+```yaml
+my_glossary:
+  type: glossary
+  permspace:
+    definition: "Permanent table storage granted to a database, in bytes."
+    synonyms:
+      - perm
+      - permanent space
+  spool:
+    definition: "Temporary intermediate storage used by Teradata query execution."
+    synonyms:
+      - spool space
+  skew_factor:
+    definition: |
+      Distribution skew across AMPs, (max - avg) / max * 100. Above ~30%
+      indicates a primary-index choice that should be reviewed.
+    synonyms:
+      - skew
+      - amp skew
+```
+
+**Required:** each term has a `definition`. **Optional:** `synonyms` (list of strings).
+
+The server **enriches the glossary automatically** with terms derived from cube measure and dimension descriptions — so if you have a cube exposing `current_perm_bytes`, that becomes a glossary-discoverable term without you defining it explicitly.
+
+---
+
+## File organisation conventions
+
+```
+my-config/
+├── profiles.yml              # always at the root, name fixed
+├── dbc_demo_objects.yml      # one file per domain / area
+├── sales_objects.yml
+└── finance_objects.yml
+```
+
+Object **names must be globally unique** across all files (later files override earlier ones by key). Profile **regex selectors** then carve up that flat namespace. Keep one file per business area so a single grep tells you what a domain exposes.

--- a/agentic/skills/teradata-mcp-customisation/reference/parameter-substitution.md
+++ b/agentic/skills/teradata-mcp-customisation/reference/parameter-substitution.md
@@ -1,0 +1,96 @@
+# Parameter substitution
+
+Custom tools and cubes can take runtime parameters. The server supports **two substitution styles** in the SQL body; both can be used in the same statement.
+
+## `:name` — SQLAlchemy named bind parameter (for values)
+
+The default style. Use for literal values: dates, numbers, strings, filter predicates.
+
+```yaml
+get_recent_events:
+  type: tool
+  sql: |
+    SELECT *
+    FROM events_table
+    WHERE event_date >= :start_date
+      AND severity   >= :min_severity
+  parameters:
+    start_date:   { type_hint: str,   description: "'YYYY-MM-DD'" }
+    min_severity: { type_hint: int,   description: "0..5" }
+```
+
+Pros: SQL-injection-safe, types preserved through the driver, query plan can be cached.
+
+**You cannot bind identifiers** (database, schema, table, column names) this way — the driver will quote them as literal strings, producing `SELECT * FROM 'DBC.AllSpaceV'` and an error.
+
+## `{name}` — Python format-string interpolation (for identifiers)
+
+When *any* `{…}` placeholder is present in the SQL body, the server first runs `sql.format_map(...)` against the supplied kwargs, then passes the resulting SQL to the bind-parameter step. This lets you parameterise table and database names.
+
+```yaml
+list_table_columns:
+  type: tool
+  sql: |
+    SELECT ColumnName, ColumnType
+    FROM DBC.ColumnsV
+    WHERE DatabaseName = '{database_name}'
+      AND TableName    = '{table_name}'
+    ORDER BY ColumnId
+  parameters:
+    database_name: { type_hint: str, description: "Schema name." }
+    table_name:    { type_hint: str, description: "Table name." }
+```
+
+**Risk:** identifier interpolation is *not* injection-safe in general. If your tool may be called by an untrusted client, validate the values (e.g. uppercase ASCII + underscore) before relying on this. For most internal MCP deployments, the caller is the LLM and the surface is small enough to be acceptable.
+
+### The synthetic `{table_ref}` key
+
+When the SQL contains `{table_ref}`, the server synthesises it from `database_name` + `table_name`:
+- both given → `database_name.table_name`
+- only `table_name` → `table_name`
+
+This lets you write:
+```yaml
+sql: |
+  SELECT COUNT(*) AS row_count FROM {table_ref}
+parameters:
+  database_name: { type_hint: str, default: "" }
+  table_name:    { type_hint: str }
+```
+
+Both `database_name` and `table_name` are consumed by `format_map` and **not** also passed as bind params — so the tool is internally consistent even if you also reference them as `:database_name` elsewhere (don't — pick one style per parameter).
+
+## Mixing the two styles
+
+Allowed and common: identifiers via `{…}`, values via `:…`.
+
+```yaml
+top_n_by_size:
+  type: tool
+  sql: |
+    SELECT TOP :n DataBaseName, SUM(CurrentPerm) AS perm
+    FROM {database_name}.AllSpaceV
+    WHERE TableName = 'All'
+    GROUP BY DataBaseName
+    ORDER BY perm DESC
+  parameters:
+    database_name: { type_hint: str, default: "DBC" }
+    n:             { type_hint: int, default: 10 }
+```
+
+## `type_hint` values
+
+Resolved against `{str, int, float, bool, list, dict, Any}`. Anything else (`"datetime"`, `"Decimal"`, …) silently falls back to `str`. If you need richer typing, validate inside your SQL (`CAST(:x AS DATE)`) instead.
+
+## The auto-added `persist` parameter
+
+Every custom tool gets a `persist: bool = False` parameter automatically. When the LLM passes `persist=True`, the server materialises the result into a volatile table and returns the table name as a string, rather than streaming rows. This is the canonical way to chain tool calls — e.g. write the output of one tool, then have a second tool join against it by name.
+
+You do not declare `persist` yourself; do not collide with the name.
+
+## Required vs optional
+
+- **Custom tools / cubes:** a parameter is **required** if its YAML entry has no `default:`. Add a `default:` to make it optional.
+- **Prompts:** opposite default — a parameter is required unless `required: false` is set (or a `default:` is provided).
+
+Keep required parameters to a minimum. Every required parameter is one more thing the LLM must successfully infer from the user's question.

--- a/agentic/skills/teradata-mcp-customisation/reference/profiles.md
+++ b/agentic/skills/teradata-mcp-customisation/reference/profiles.md
@@ -1,0 +1,136 @@
+# `profiles.yml`
+
+Profiles select **which objects** the server exposes for a given launch and (optionally) **how the server runs** (transport, port, database URI). The selectors are regex patterns matched against object names; the runtime block is plain key/value.
+
+## Layering
+
+The server loads profiles in this order:
+
+1. **Packaged profiles** from `src/teradata_mcp_server/config/profiles.yml` (ships with the install).
+2. **Your `profiles.yml`** in the config directory — replaces the packaged file at the **top-level key** (whole-profile replace, no merge).
+
+Pick the profile at launch via `--profile <name>` or `$PROFILE`. If unset (or `all`), the `all` packaged profile is used: everything loads.
+
+## Schema
+
+```yaml
+profile_name:
+  tool:
+    - regex_pattern_.*
+    - exact_tool_name
+  prompt:
+    - regex_pattern_.*
+  resource:
+    - regex_pattern_.*
+  registry: "schema_name"          # optional — load tools from a DB tool registry
+  run:                             # optional — overrides startup settings
+    database_uri: "teradata://${TD_USER}:${TD_PASSWORD}@host:1025"
+    mcp_transport: "streamable-http"
+    mcp_port: 8001
+```
+
+- Each section's value is a **list of regex patterns**. An object matches if **any** pattern matches its name. Patterns are not anchored automatically — write `^foo_.*` if you want a prefix match (`foo_.*` alone matches names containing `foo_` anywhere).
+- `tool:` selects both `type: tool` and `type: cube` objects.
+- `prompt:` selects `type: prompt` objects.
+- `resource:` selects `type: glossary` objects (and any future resource types).
+
+## Built-in profiles you can mirror or extend
+
+Excerpt of the packaged `profiles.yml` (see upstream for the source of truth):
+
+```yaml
+all:
+  tool:     [".*"]
+  prompt:   ["^(?!test_).*"]
+  resource: [".*"]
+
+eda:
+  tool:
+    - "base_(?!(writeQuery|dynamicQuery)$).*"  # read-only base tools only
+    - qlty_.*
+    - sec_userDbPermissions
+
+dba:
+  tool:    ["^dba_*", "^base_*", "^sec_*"]
+  prompt:  ["^dba_*"]
+
+dataScientist:
+  tool:
+    - ^base_*
+    - ^rag_*
+    - ^sql_*
+    - ^fs_*
+    - ^qlty_*
+    - ^tdvs_*
+    - ^sec_userDbPermissions
+    - ^dba_userSqlList
+    - ^plot_*
+    - ^tdml_*
+  prompt: ["^rag_*", "^sql_*", "^tdvs_*"]
+```
+
+Useful patterns when composing your own profile:
+
+| Goal | Pattern |
+|---|---|
+| All your domain objects | `^mydomain_.*` |
+| All read-only base tools (no DDL/DML, no dynamic SQL) | `base_(?!(writeQuery\|dynamicQuery)$).*` |
+| Data-quality tools | `qlty_.*` |
+| Single user's permissions check | `sec_userDbPermissions` |
+| Everything except tests | `^(?!test_).*` |
+
+## Composing a "business" + "exploration" profile
+
+A common shape: one profile that exposes **only your curated semantic layer** for an end-user chat, and a second profile that adds read-only base tools for analysts who need to free-form explore.
+
+```yaml
+sales_business:
+  tool:
+    - sales_.*_cube
+  prompt:
+    - sales_.*
+  resource:
+    - sales_.*
+  run:
+    mcp_transport: "streamable-http"
+    mcp_port: 8006
+
+sales_super:
+  tool:
+    - sales_.*_cube
+    - "base_(?!(writeQuery|dynamicQuery)$).*"
+    - qlty_.*
+  prompt:
+    - sales_.*
+  resource:
+    - sales_.*
+  run:
+    mcp_transport: "streamable-http"
+    mcp_port: 8007
+```
+
+Different ports per profile let you run both side-by-side and point different clients at each.
+
+## The `registry:` field (database-backed tools)
+
+If set, the server reads two views from that schema at startup:
+
+- `<schema>.mcp_list_tools` — rows describing tools (name, object, description)
+- `<schema>.mcp_list_toolParams` — rows describing each tool's parameters
+
+Registered objects can be UDFs (`F`), Macros (`M`), Tables (`T`), or Views (`V`). Registry-loaded tools are **not filtered by the profile's regex selectors** — turning on the registry exposes everything in it. Use a separate schema per profile if you need scoping.
+
+## `run:` block
+
+Anything you'd otherwise set via env / CLI:
+
+- `database_uri` — full SQLAlchemy URI with `${VAR}` env-var substitution.
+- `mcp_transport` — `streamable-http`, `sse`, `stdio`.
+- `mcp_port` — only meaningful for HTTP transports.
+- `logging_level`, `config_dir`, etc. — anything in `Settings`.
+
+Values here override env and CLI for that profile. Use this to bind a profile to a specific environment without juggling `.env` files.
+
+## Validating
+
+After editing `profiles.yml`, restart the server and verify with the smoke-test in `deployment.md`. A missing object in `tools/list` is almost always a regex that doesn't match (forgetting `^`, or putting the object in the wrong section — e.g. glossary in `tool:`).


### PR DESCRIPTION
Add teradata-mcp-customisation skill to agentic/skills/

This PR adds a Claude Code skill for building and debugging the Teradata MCP server's semantic layer — custom tools, cubes, prompts, and glossary entries declared in YAML.

The skill captures the parts of the customisation surface that are easy to get wrong: cube SQL wrapping semantics, dim_filters vs meas_filters scoping, parameter substitution styles (:name vs {name}), profile regex selection, and the streamable-HTTP smoke-test flow. It includes five portable worked examples targeting DBC system views so anyone with Teradata access can run them without sample data.

Why here: the skill's reference docs and examples must stay in sync with the server's customisation API. Co-locating them in agentic/skills/ makes that a natural part of maintaining the server itself — a docs or schema change in src/ has an obvious companion update path. The directory is outside the src/teradata_mcp_server package tree and is never included in PyPI builds.