### PR TITLE
fix: replace DBC V views with VX views for row-level access control (issue #334)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "teradata-mcp-server"
-version = "0.2.3"
+version = "0.2.4"
 
 description = "Model Context Protocol (MCP) server for Teradata, Community edition"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/teradata_mcp_server/app.py
+++ b/src/teradata_mcp_server/app.py
@@ -255,7 +255,7 @@ def create_mcp_app(settings: Settings):
                                 current_user = username_row[0]
                                 check_permission_sql = text(f"""
                                     SELECT 1
-                                    FROM DBC.AllRightsV
+                                    FROM DBC.AllRightsVX
                                     WHERE UPPER(UserName) = UPPER('{current_user}')
                                     AND UPPER(DatabaseName) = UPPER('{function_db}')
                                     AND (

--- a/src/teradata_mcp_server/tools/base/base_objects.yml
+++ b/src/teradata_mcp_server/tools/base/base_objects.yml
@@ -8,7 +8,7 @@ base_databaseList:
       default: 'user'
   sql: |
     SELECT DataBaseName, DECODE(DBKind, 'U', 'User', 'D', 'DataBase') AS DBType, CommentString
-    FROM dbc.DatabasesV dv
+    FROM dbc.DatabasesVX dv
     WHERE OwnerName <> 'PDCRADM'
     AND (:scope = 'all' OR (
         DataBaseName NOT IN (
@@ -34,7 +34,7 @@ base_tableList:
       default: ''
   sql: |
     SELECT DatabaseName, TableName
-    FROM dbc.TablesV tv
+    FROM dbc.TablesVX tv
     WHERE tv.TableKind IN ('T','V', 'O', 'Q')
     AND (:database_name = '' OR UPPER(tv.DatabaseName) = UPPER(:database_name));
 

--- a/src/teradata_mcp_server/tools/base/base_tools.py
+++ b/src/teradata_mcp_server/tools/base/base_tools.py
@@ -1315,7 +1315,7 @@ def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None 
     """
     Retrieve all qualifying objects (tables, views, functions) from a database.
 
-    Queries DBC.TablesV filtered by TableKind. Defaults to
+    Queries DBC.TablesVX filtered by TableKind. Defaults to
     ('T','O','Q','V') — tables, NoPI tables, queue tables, and views.
 
     Resolution paths used downstream by _process_one:
@@ -1350,7 +1350,7 @@ def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None 
             tv.DatabaseName  AS DatabaseName
            ,tv.TableName     AS ObjectName
            ,tv.TableKind     AS TableKind
-        FROM DBC.TablesV AS tv
+        FROM DBC.TablesVX AS tv
         WHERE tv.DatabaseName = ?
           AND tv.TableKind IN ({placeholders})
         ORDER BY tv.TableName
@@ -1370,7 +1370,7 @@ def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None 
 
 def _get_table_kind(conn: TeradataConnection, db_name: str, object_name: str) -> str | None:
     """
-    Look up the TableKind for a single object in DBC.TablesV.
+    Look up the TableKind for a single object in DBC.TablesVX.
 
     Args:
         conn:        TeradataConnection (injected by MCP server).
@@ -1382,7 +1382,7 @@ def _get_table_kind(conn: TeradataConnection, db_name: str, object_name: str) ->
     """
     sql = """
         SELECT tv.TableKind
-        FROM DBC.TablesV AS tv
+        FROM DBC.TablesVX AS tv
         WHERE tv.DatabaseName = ?
           AND tv.TableName    = ?
     """

--- a/src/teradata_mcp_server/tools/dba/dba_objects.yml
+++ b/src/teradata_mcp_server/tools/dba/dba_objects.yml
@@ -23,7 +23,7 @@ dba_tableSpace:
         SUM(a.CurrentPerm) AS CurrentPerm1, SUM(a.PeakPerm) AS PeakPerm,
         CAST((100-(AVG(a.CURRENTPERM)/MAX(NULLIFZERO(a.CURRENTPERM))*100)) AS DECIMAL(5,2)) AS SkewPct
     FROM DBC.AllSpaceV a
-    LEFT JOIN DBC.TablesV t ON a.DatabaseName = t.DatabaseName AND a.TableName = t.TableName
+    LEFT JOIN DBC.TablesVX t ON a.DatabaseName = t.DatabaseName AND a.TableName = t.TableName
     WHERE (:database_name = '' OR a.DatabaseName = :database_name)
     AND (:table_name = '' OR a.TableName = :table_name)
     AND (:exclude_system <> 'Y' OR (
@@ -101,7 +101,7 @@ dba_databaseSpace:
         CAST(SUM(CurrentPerm)/1024/1024/1024 AS DECIMAL(10,2)) AS SpaceUsed_GB,
         CAST((SUM(MaxPerm) - SUM(CurrentPerm))/1024/1024/1024 AS DECIMAL(10,2)) AS FreeSpace_GB,
         CAST((SUM(CurrentPerm) * 100.0 / NULLIF(SUM(MaxPerm),0)) AS DECIMAL(10,2)) AS PercentUsed
-    FROM DBC.DiskSpaceV
+    FROM DBC.DiskSpaceVX
     WHERE MaxPerm > 0
     AND (:database_name = '' OR DatabaseName = :database_name)
     GROUP BY 1
@@ -387,18 +387,18 @@ dba_sessionInfo:
         UserName,
         AccountName,
         SessionNo,
-        DefaultDataBase, 
+        DefaultDataBase,
         LogonDate,
         LogonTime,
-        LogonSource, 
+        LogonSource,
         LogonAcct,
-        CurrentRole, 
+        CurrentRole,
         QueryBand,
-        ClientIpAddress, 
+        ClientIpAddress,
         ClientProgramName,
         ClientSystemUserId,
         ClientInterfaceVersion
-    FROM DBC.SessionInfoV
+    FROM DBC.SessionInfoVX
     WHERE UserName = :user_name (NOT CASESPECIFIC) or :user_name='*';
   parameters:
     user_name:

--- a/src/teradata_mcp_server/tools/sec/sec_objects.yml
+++ b/src/teradata_mcp_server/tools/sec/sec_objects.yml
@@ -13,7 +13,7 @@ sec_userDbPermissions:
         AccessRight,
         GrantAuthority,
         GrantorName
-    FROM DBC.AllRightsV
+    FROM DBC.AllRightsVX
     WHERE UserName = :user_name
     ORDER BY DatabaseName, TableName, AccessRight;
 
@@ -112,7 +112,7 @@ sec_userRoles:
         Rm.WhenGranted,
         Rm.DefaultRole,
         Rm.WithAdmin
-    FROM DBC.RoleInfoV r
-    JOIN DBC.RoleMembersV Rm
+    FROM DBC.RoleInfoVX r
+    JOIN DBC.RoleMembersVX Rm
     ON r.RoleName = Rm.RoleName
     WHERE r.RoleName LIKE '%' || :user_name || '%' (NOT CASESPECIFIC);

--- a/uv.lock
+++ b/uv.lock
@@ -4449,7 +4449,7 @@ wheels = [
 
 [[package]]
 name = "teradata-mcp-server"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Replace unrestricted DBC dictionary "V" views with access-controlled "VX" views across 7 MCP tools to prevent exposing metadata to users without appropriate permissions.

This fixes issue #334 where tools were using `DBC.TablesV`, `DBC.DatabasesV`, `DBC.SessionInfoV`, `DBC.AllRightsV`, `DBC.RoleInfoV`, `DBC.RoleMembersV`, and `DBC.DiskSpaceV` which return results for all users regardless of their database access level.

## Changes
- **sec_userDbPermissions**: AllRightsV → AllRightsVX
- **sec_userRoles**: RoleInfoV/RoleMembersV → RoleInfoVX/RoleMembersVX
- **dba_sessionInfo**: SessionInfoV → SessionInfoVX
- **dba_databaseSpace**: DiskSpaceV → DiskSpaceVX
- **dba_tableSpace**: TablesV → TablesVX (in join)
- **base_tableList**: TablesV → TablesVX
- **base_databaseList**: DatabasesV → DatabasesVX
- **base_tools.py**: TablesV → TablesVX in `_get_objects()` and `_get_table_kind()`
- **app.py**: AllRightsV → AllRightsVX in authorization check

## Technical Details
VX views are drop-in replacements that apply row-level filtering based on the executing user's permissions. This means:
- No functional logic changes to tools
- Teradata handles security filtering automatically
- Users will only see objects they have access to (intended security improvement)

## Testing
✅ Unit tests passing

## Files Changed
- src/teradata_mcp_server/tools/sec/sec_objects.yml
- src/teradata_mcp_server/tools/dba/dba_objects.yml
- src/teradata_mcp_server/tools/base/base_objects.yml
- src/teradata_mcp_server/tools/base/base_tools.py
- src/teradata_mcp_server/app.py

Fixes #334