### PR TITLE
Improve LLM routing clarity for dba, sec, qlty, plot modules (issues #344-347)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Add this to `claude_desktop_config.json` (Settings > Developer > Edit Config):
 | **Query & Analyze** | Explore tables, profile data, explain results, visualize patterns—no SQL needed | [base](src/teradata_mcp_server/tools/base/README.md), [dba](src/teradata_mcp_server/tools/dba/README.md), [qlty](src/teradata_mcp_server/tools/qlty/README.md), [plot](src/teradata_mcp_server/tools/plot/README.md) |
 | **AI & RAG Pipelines** | Semantic search, retrieval-augmented generation, vector storage | [rag](src/teradata_mcp_server/tools/rag/README.md), [tdvs](src/teradata_mcp_server/tools/tdvs/README.md), [fs](src/teradata_mcp_server/tools/fs/README.md) |
 | **Database Admin** | Manage security, monitor capacity, automate backups | [dba](src/teradata_mcp_server/tools/dba/README.md), [sec](src/teradata_mcp_server/tools/sec/README.md), [bar](src/teradata_mcp_server/tools/bar/README.md) |
-
-| **Custom Logic** | Define domain tools, metrics, and semantic layers in YAML | Customization (no code required) |
+| **Custom Logic** | Define domain tools, metrics, and semantic layers in YAML | [Learn more →](docs/server_guide/CUSTOMIZING.md) |
 
 ## What's New (Latest Release)
 

--- a/src/teradata_mcp_server/tools/base/base_objects.yml
+++ b/src/teradata_mcp_server/tools/base/base_objects.yml
@@ -26,11 +26,12 @@ base_databaseList:
 
 base_tableList:
   type: tool
-  description: "List all tables and views within a specific Teradata database or schema. ONLY call this tool when the user has explicitly named a specific database in their message. If no database name appears in the user's request, do NOT call this tool — instead ask a clarifying question to find out which database they mean. Never pass an empty database name. Do NOT use when the user is asking which databases exist on the system — use base_databaseList for that."
+  description: "List all tables and views within a specific Teradata database or schema. Pass a specific database name to list tables in that database only. Omit or leave empty to list tables from all databases. If the user does not name a database and you want to list tables from a single database, ask a clarifying question instead of returning results from all databases."
   parameters:
     database_name:
-      description: "Database name"
+      description: "Database name. Leave empty to list tables from all databases."
       type_hint: str
+      default: ''
   sql: |
     SELECT DatabaseName, TableName
     FROM dbc.TablesVX tv
@@ -47,7 +48,6 @@ base_tableDDL:
     database_name:
       description: "Database name"
       type_hint: str
-      default: ''
   sql: |
     SHOW TABLE {table_ref}
 

--- a/src/teradata_mcp_server/tools/base/base_objects.yml
+++ b/src/teradata_mcp_server/tools/base/base_objects.yml
@@ -1,6 +1,6 @@
 base_databaseList:
   type: tool
-  description: "Lists databases in the Teradata System."
+  description: "List all databases or schemas available in the Teradata system. ONLY call when the user explicitly asks which databases or schemas exist on the system. Do NOT call this tool as a preliminary step toward listing tables — if the user asks about tables without naming a database, ask them which database they mean rather than discovering databases first."
   parameters:
     scope:
       description: "Filter scope: 'user' returns only user-created databases (excludes system databases), 'all' returns every database."
@@ -26,12 +26,11 @@ base_databaseList:
 
 base_tableList:
   type: tool
-  description: "Lists all tables and views in a database."
+  description: "List all tables and views within a specific Teradata database or schema. ONLY call this tool when the user has explicitly named a specific database in their message. If no database name appears in the user's request, do NOT call this tool — instead ask a clarifying question to find out which database they mean. Never pass an empty database name. Do NOT use when the user is asking which databases exist on the system — use base_databaseList for that."
   parameters:
     database_name:
-      description: "Database name. Leave empty for all databases."
+      description: "Database name"
       type_hint: str
-      default: ''
   sql: |
     SELECT DatabaseName, TableName
     FROM dbc.TablesVX tv
@@ -40,7 +39,7 @@ base_tableList:
 
 base_tableDDL:
   type: tool
-  description: "Displays the DDL definition of a table."
+  description: "Return the CREATE TABLE DDL statement for a Teradata table, showing its full schema definition including column types, constraints, primary indexes, and keys. Use when the user wants the CREATE statement, the table definition, or needs to see how the table was built. If the user has not specified both a table name AND a database name, ask for clarification before calling — do not guess or use an empty database name. To save DDL to a file on disk, use base_saveDDL instead. For just column names and types, use base_columnDescription instead."
   parameters:
     table_name:
       description: "Table name"
@@ -54,7 +53,7 @@ base_tableDDL:
 
 base_columnDescription:
   type: tool
-  description: "Shows detailed column information about a database table or view."
+  description: "List the column names, data types, and basic attributes for a single Teradata table or view. Use for straightforward questions like 'what columns does this table have?' or 'what are the fields and their types?'. For precise Teradata-specific type codes, character sets, decimal precision, index details, or bulk metadata across many objects, use base_columnMetadata instead."
   parameters:
     database_name:
       description: "Database name. Defaults to '%' (all databases)."
@@ -117,7 +116,7 @@ base_columnDescription:
 
 base_tablePreview:
   type: tool
-  description: "Returns a data sample (top 5 rows) and inferred structure from a database table or view."
+  description: "Return a quick sample of the first few rows from a Teradata table or view so the user can see what data looks like, with no SQL required. Use this tool when the user wants to explore or peek at a table's contents without specifying conditions or writing a query. Do NOT use when the user provides a WHERE clause, filter, or explicit SQL statement — use base_readQuery for that."
   parameters:
     table_name:
       description: "Table or view name"
@@ -131,7 +130,7 @@ base_tablePreview:
 
 base_tableAffinity:
   type: tool
-  description: "Get tables commonly used together by database users, helpful to infer relationships between tables."
+  description: "Identify which tables in a database tend to co-occur together in the same SQL queries, revealing natural JOIN relationships and data affinity patterns. Use when the user asks which tables are queried together, what tables are related to a specific table, or what tables are commonly used in the same workflows. For access frequency, query counts, or per-user access statistics, use base_tableUsage instead."
   parameters:
     database_name:
       description: "Database name"
@@ -173,7 +172,7 @@ base_tableAffinity:
 
 base_tableUsage:
   type: tool
-  description: "Measure the usage of tables and views by users in a schema, helpful to infer what database objects are most actively used."
+  description: "Report access frequency and per-user query patterns for tables and views in a Teradata database, showing which objects are most actively queried and by whom. Use when the user asks how often tables are accessed, which tables are most popular, or which users are running queries against a database. For discovering which tables appear together in the same queries, use base_tableAffinity instead."
   parameters:
     database_name:
       description: "Database name. Leave empty for all databases."

--- a/src/teradata_mcp_server/tools/base/base_objects.yml
+++ b/src/teradata_mcp_server/tools/base/base_objects.yml
@@ -59,7 +59,7 @@ base_columnDescription:
       description: "Database name. Defaults to '%' (all databases)."
       type_hint: str
       default: '%'
-    obj_name:
+    table_name:
       description: "Table or view name. Defaults to '%' (all tables)."
       type_hint: str
       default: '%'
@@ -111,7 +111,7 @@ base_columnDescription:
         WHEN '??' THEN 'STGEOMETRY''ANY_TYPE'
         END AS CType
     FROM DBC.ColumnsVX
-    WHERE UPPER(tableName) LIKE UPPER(:obj_name)
+    WHERE UPPER(tableName) LIKE UPPER(:table_name)
     AND UPPER(DatabaseName) LIKE UPPER(:database_name);
 
 base_tablePreview:

--- a/src/teradata_mcp_server/tools/base/base_tools.py
+++ b/src/teradata_mcp_server/tools/base/base_tools.py
@@ -201,7 +201,7 @@ def util_base_dynamicQuery(conn: TeradataConnection, sql_generator: Callable[...
 def handle_base_saveDDL(
     conn: TeradataConnection,
     database_name: str,
-    object_name: str,
+    table_name: str,
     object_type: str = "PROCEDURE",
     output_dir: str = "./ddls_extracted",
     *args,
@@ -212,7 +212,7 @@ def handle_base_saveDDL(
 
     Arguments:
       database_name - Database name (e.g., 'MKTG_USR')
-      object_name - Object name (e.g., 'SP_LOAD_VARIABLES_ARGUMENTARIO_IAG_FICHA_CLIENTE')
+      table_name - Object name (e.g., 'SP_LOAD_VARIABLES_ARGUMENTARIO_IAG_FICHA_CLIENTE'). Accepts comma-separated values for bulk retrieval.
       object_type - Type of object: 'PROCEDURE', 'TABLE', 'VIEW' (default: 'PROCEDURE')
       output_dir - Directory where to save the DDL file (default: './ddls_extracted')
 
@@ -225,7 +225,7 @@ def handle_base_saveDDL(
 
     logger.debug(
         f"Tool: handle_base_saveDDL: Args: database_name={database_name}, "
-        f"object_name={object_name}, object_type={object_type}, output_dir={output_dir}"
+        f"table_name={table_name}, object_type={object_type}, output_dir={output_dir}"
     )
 
     # Validate object type
@@ -238,11 +238,11 @@ def handle_base_saveDDL(
 
     # Build the SHOW command
     show_commands = {
-        "PROCEDURE": f"SHOW PROCEDURE {database_name}.{object_name}",
-        "TABLE": f"SHOW TABLE {database_name}.{object_name}",
-        "VIEW": f"SHOW VIEW {database_name}.{object_name}",
-        "MACRO": f"SHOW MACRO {database_name}.{object_name}",
-        "FUNCTION": f"SHOW FUNCTION {database_name}.{object_name}",
+        "PROCEDURE": f"SHOW PROCEDURE {database_name}.{table_name}",
+        "TABLE": f"SHOW TABLE {database_name}.{table_name}",
+        "VIEW": f"SHOW VIEW {database_name}.{table_name}",
+        "MACRO": f"SHOW MACRO {database_name}.{table_name}",
+        "FUNCTION": f"SHOW FUNCTION {database_name}.{table_name}",
     }
 
     sql = show_commands[object_type_upper]
@@ -255,7 +255,7 @@ def handle_base_saveDDL(
             raw_rows = rows.fetchall()
 
             if not raw_rows:
-                error_msg = f"No DDL found for {object_type} {database_name}.{object_name}"
+                error_msg = f"No DDL found for {object_type} {database_name}.{table_name}"
                 logger.warning(error_msg)
                 return create_response([{"error": error_msg}], {"tool_name": "base_saveDDL", "status": "not_found"})
 
@@ -277,7 +277,7 @@ def handle_base_saveDDL(
 
             # Generate filename
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"{object_name}_DDL.sql"
+            filename = f"{table_name}_DDL.sql"
             filepath = output_path / filename
 
             # Prepare file header with metadata
@@ -286,7 +286,7 @@ def handle_base_saveDDL(
  * Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
  * Type: {object_type_upper}
  * Database: {database_name}
- * Object: {object_name}
+ * Object: {table_name}
  * Size: {ddl_size} characters
  */
 
@@ -312,7 +312,7 @@ def handle_base_saveDDL(
                     "rows_concatenated": len(raw_rows),
                     "object_type": object_type_upper,
                     "database": database_name,
-                    "object": object_name,
+                    "object": table_name,
                 }
             ]
 
@@ -471,7 +471,7 @@ DEFAULT_MAX_WORKERS = 8
 # Column metadata tool
 def handle_base_columnMetadata(
     conn: TeradataConnection,
-    db_name: str,
+    database_name: str,
     object_name: str | None = None,
     table_kind: str | None = None,
     max_workers: int | None = None,
@@ -550,12 +550,12 @@ def handle_base_columnMetadata(
 
     CONTINUATION PATTERN (automatic pagination):
         # Call 1 — starts processing, time or payload budget fills up
-        result1 = base_columnMetadata(db_name='DBC', table_kind='V', ...)
+        result1 = base_columnMetadata(database_name='DBC', table_kind='V', ...)
         # metadata contains: remaining_objects='ViewX,ViewY,...'
 
         # Call 2 — pass remaining_objects as object_name
         result2 = base_columnMetadata(
-            db_name='DBC',
+            database_name='DBC',
             object_name='ViewX,ViewY,...',  # from result1 metadata
             ...
         )
@@ -563,7 +563,7 @@ def handle_base_columnMetadata(
 
     Typical call for a large database:
         base_columnMetadata(
-            db_name='DBC',
+            database_name='DBC',
             table_kind='V',
             exclude_objects='ResUsage%,%ResUsage%',
             fields='ColumnName,ColumnType,ColumnLength,CharType,
@@ -575,7 +575,7 @@ def handle_base_columnMetadata(
 
     Arguments:
         conn                  - TeradataConnection (injected by MCP server)
-        db_name               - Name of the Teradata database to inspect
+        database_name         - Name of the Teradata database to inspect
         object_name           - Optional: specific object name, or a CSV of
                                 names. Also used for continuation: pass the
                                 ``remaining_objects`` value from a previous
@@ -665,7 +665,7 @@ def handle_base_columnMetadata(
         # ------------------------------------------------------------------
         v_step_no = "010"
         logger.debug(
-            f"{C_MODULE}:{v_step_no} Resolving objects for db_name={db_name}, "
+            f"{C_MODULE}:{v_step_no} Resolving objects for database_name={database_name}, "
             f"object_name={object_name}, exclude_objects={exclude_objects}"
         )
 
@@ -674,18 +674,18 @@ def handle_base_columnMetadata(
             names = [n.strip() for n in object_name.split(",") if n.strip()]
             obj_infos = []
             for name in names:
-                kind = _get_table_kind(conn, db_name, name)
+                kind = _get_table_kind(conn, database_name, name)
                 if kind:
                     obj_infos.append({"ObjectName": name, "TableKind": kind})
                 else:
                     logger.warning(
-                        f"{C_MODULE}:{v_step_no} Object '{name}' not found in database '{db_name}' — skipping"
+                        f"{C_MODULE}:{v_step_no} Object '{name}' not found in database '{database_name}' — skipping"
                     )
             if not obj_infos:
-                raise ValueError(f"None of the specified objects found in '{db_name}'")
+                raise ValueError(f"None of the specified objects found in '{database_name}'")
         else:
             # Retrieve all qualifying objects in the database
-            obj_infos = _get_objects(conn, db_name, table_kind=table_kind)
+            obj_infos = _get_objects(conn, database_name, table_kind=table_kind)
 
         logger.debug(f"{C_MODULE}:{v_step_no} Found {len(obj_infos)} object(s) to process")
 
@@ -762,9 +762,9 @@ def handle_base_columnMetadata(
             results = []
             try:
                 if kind == "V":
-                    cols = _help_column_view(conn, db_name, obj, logger)
+                    cols = _help_column_view(conn, database_name, obj, logger)
                 else:
-                    cols = _dbc_columns_table(conn, db_name, obj)
+                    cols = _dbc_columns_table(conn, database_name, obj)
 
                 for col in cols:
                     # Skip type-building for error/status records — these have
@@ -785,7 +785,7 @@ def handle_base_columnMetadata(
                     results.append(col)
 
             except Exception as obj_ex:
-                logger.warning(f'{C_MODULE}:{v_step_no} Skipping {db_name}."{obj}" (TableKind={kind}): {obj_ex}')
+                logger.warning(f'{C_MODULE}:{v_step_no} Skipping {database_name}."{obj}" (TableKind={kind}): {obj_ex}')
                 results.append(
                     {
                         "ObjectName": obj,
@@ -878,7 +878,7 @@ def handle_base_columnMetadata(
 
         metadata = {
             "tool_name": C_MODULE,
-            "database": db_name,
+            "database": database_name,
             "object_count": len(processed_objects),
             "column_count": len(data),
             "payload_kb": accumulated_bytes // 1024,
@@ -910,7 +910,7 @@ def handle_base_columnMetadata(
         logger.error(f"{C_MODULE}:{v_step_no} Error: {e}")
         return create_response(
             [{"error": str(e)}],
-            {"tool_name": C_MODULE, "database": db_name},
+            {"tool_name": C_MODULE, "database": database_name},
         )
 
 
@@ -990,7 +990,7 @@ def _standardise_helpcol_row(row: dict) -> dict:
 
 def _columnsVX_fallback(
     conn: TeradataConnection,
-    db_name: str,
+    database_name: str,
     object_name: str,
     logger: logging.Logger,
 ) -> list:
@@ -1015,9 +1015,9 @@ def _columnsVX_fallback(
     Each returned row includes metadata_source='DBC.ColumnsVX' to signal this.
 
     Args:
-        conn:        TeradataConnection (injected by MCP server).
-        db_name:     Target database name.
-        object_name: The view name.
+        conn:           TeradataConnection (injected by MCP server).
+        database_name:  Target database name.
+        object_name:    The view name.
         logger:      Logger instance for error reporting.
 
     Returns:
@@ -1046,7 +1046,7 @@ def _columnsVX_fallback(
     """
     try:
         with conn.cursor() as cur:
-            cur.execute(sql, [db_name, object_name])
+            cur.execute(sql, [database_name, object_name])
             rows = cur.fetchall()
             data = rows_to_json(cur.description, rows)
 
@@ -1076,7 +1076,7 @@ def _columnsVX_fallback(
             return results
 
     except Exception as ex:
-        logger.error(f'{C_MODULE}: DBC.ColumnsVX fallback failed for {db_name}."{object_name}" — {ex}')
+        logger.error(f'{C_MODULE}: DBC.ColumnsVX fallback failed for {database_name}."{object_name}" — {ex}')
         return [
             {
                 "ObjectName": object_name,
@@ -1305,7 +1305,7 @@ def _build_charset_string(col: dict) -> str | None:
     return CHARSET_MAP.get(char_type)
 
 
-def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None = None) -> list[dict[str, str]]:
+def _get_objects(conn: TeradataConnection, database_name: str, table_kind: str | None = None) -> list[dict[str, str]]:
     """
     Retrieve all qualifying objects (tables, views, functions) from a database.
 
@@ -1329,9 +1329,9 @@ def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None 
     Other:              TableKind 'C' (table operator), 'U' (type), 'H' (method)
 
     Args:
-        conn:       TeradataConnection (injected by MCP server).
-        db_name:    Target database name.
-        table_kind: Optional CSV of TableKind codes, e.g. 'V' or 'T,V'.
+        conn:           TeradataConnection (injected by MCP server).
+        database_name:  Target database name.
+        table_kind:     Optional CSV of TableKind codes, e.g. 'V' or 'T,V'.
 
     Returns:
         list[dict]: Each dict contains DatabaseName, ObjectName, TableKind.
@@ -1350,7 +1350,7 @@ def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None 
         ORDER BY tv.TableName
     """
     with conn.cursor() as cur:
-        cur.execute(sql, [db_name] + kinds)
+        cur.execute(sql, [database_name] + kinds)
         rows = cur.fetchall()
         return [
             {
@@ -1362,14 +1362,14 @@ def _get_objects(conn: TeradataConnection, db_name: str, table_kind: str | None 
         ]
 
 
-def _get_table_kind(conn: TeradataConnection, db_name: str, object_name: str) -> str | None:
+def _get_table_kind(conn: TeradataConnection, database_name: str, object_name: str) -> str | None:
     """
     Look up the TableKind for a single object in DBC.TablesVX.
 
     Args:
-        conn:        TeradataConnection (injected by MCP server).
-        db_name:     Target database name.
-        object_name: The specific object to look up.
+        conn:           TeradataConnection (injected by MCP server).
+        database_name:  Target database name.
+        object_name:    The specific object to look up.
 
     Returns:
         str or None: The TableKind code, or None if the object does not exist.
@@ -1381,12 +1381,12 @@ def _get_table_kind(conn: TeradataConnection, db_name: str, object_name: str) ->
           AND tv.TableName    = ?
     """
     with conn.cursor() as cur:
-        cur.execute(sql, [db_name, object_name])
+        cur.execute(sql, [database_name, object_name])
         row = cur.fetchone()
         return row[0].strip() if row else None
 
 
-def _dbc_columns_table(conn: TeradataConnection, db_name: str, object_name: str) -> list:
+def _dbc_columns_table(conn: TeradataConnection, database_name: str, object_name: str) -> list:
     """
     Retrieve column metadata for a table (T, O, Q) from DBC.ColumnsVX,
     supplemented with index classification from DBC.IndicesVX.
@@ -1421,9 +1421,9 @@ def _dbc_columns_table(conn: TeradataConnection, db_name: str, object_name: str)
     index type, the first encountered entry is retained.
 
     Args:
-        conn:        TeradataConnection (injected by MCP server).
-        db_name:     Target database name.
-        object_name: The table name (TableKind T, O, or Q).
+        conn:           TeradataConnection (injected by MCP server).
+        database_name:  Target database name.
+        object_name:    The table name (TableKind T, O, or Q).
 
     Returns:
         list[dict]: Normalised column metadata rows, each containing
@@ -1476,12 +1476,12 @@ def _dbc_columns_table(conn: TeradataConnection, db_name: str, object_name: str)
 
     with conn.cursor() as cur:
         # Fetch column metadata
-        cur.execute(col_sql, [db_name, object_name])
+        cur.execute(col_sql, [database_name, object_name])
         col_rows = cur.fetchall()
         col_data = rows_to_json(cur.description, col_rows)
 
         # Fetch index participation
-        cur.execute(idx_sql, [db_name, object_name])
+        cur.execute(idx_sql, [database_name, object_name])
         idx_rows = cur.fetchall()
         idx_data = rows_to_json(cur.description, idx_rows)
 
@@ -1538,7 +1538,7 @@ def _dbc_columns_table(conn: TeradataConnection, db_name: str, object_name: str)
 
 def _help_column_view(
     conn: TeradataConnection,
-    db_name: str,
+    database_name: str,
     object_name: str,
     logger: logging.Logger,
 ) -> list:
@@ -1565,10 +1565,10 @@ def _help_column_view(
     exception and returns a BROKEN_VIEW status record instead of raising.
 
     Args:
-        conn:        TeradataConnection (injected by MCP server).
-        db_name:     Target database name.
-        object_name: The view name.
-        logger:      Logger instance for error reporting.
+        conn:           TeradataConnection (injected by MCP server).
+        database_name:  Target database name.
+        object_name:    The view name.
+        logger:         Logger instance for error reporting.
 
     Returns:
         list[dict]: Normalised column metadata rows, or a single
@@ -1578,7 +1578,7 @@ def _help_column_view(
         HELP COLUMN dt01.*
         FROM (
             SELECT obj.*
-            FROM "{db_name}"."{object_name}" AS obj
+            FROM "{database_name}"."{object_name}" AS obj
             WHERE 1 = 0
         ) AS dt01
     """
@@ -1597,14 +1597,14 @@ def _help_column_view(
         # Fall back to DBC.ColumnsVX (backward-compatible path).
         if TD_ERR_NO_SELECT_ACCESS in ex_str:
             logger.warning(
-                f'{C_MODULE}: No SELECT privilege on {db_name}."{object_name}" '
+                f'{C_MODULE}: No SELECT privilege on {database_name}."{object_name}" '
                 f"— falling back to DBC.ColumnsVX (reduced type fidelity for "
                 f"expression-derived columns)"
             )
-            return _columnsVX_fallback(conn, db_name, object_name, logger)
+            return _columnsVX_fallback(conn, database_name, object_name, logger)
 
         # -- All other errors: treat as a broken/invalid view.
-        logger.error(f'{C_MODULE}: Broken view detected: {db_name}."{object_name}" - {ex}')
+        logger.error(f'{C_MODULE}: Broken view detected: {database_name}."{object_name}" - {ex}')
         return [
             {
                 "ObjectName": object_name,

--- a/src/teradata_mcp_server/tools/base/base_tools.py
+++ b/src/teradata_mcp_server/tools/base/base_tools.py
@@ -28,7 +28,7 @@ def handle_base_readQuery(
     **kwargs,
 ):
     """
-    Execute a user-provided SQL query against Teradata and return the results. Use this tool ONLY when the user supplies an explicit SQL statement or a request that includes filter conditions (WHERE clause, aggregations, JOINs, etc.). Do NOT use for simply browsing or sampling rows from a table — use base_tablePreview for that. Requires the sql parameter containing the full SQL text.
+    Execute a user-provided SQL query against Teradata and return the results. Use this tool ONLY when the user supplies an explicit SQL statement or a request that includes filter conditions (WHERE clause, aggregations, JOINs, etc.). Do NOT use for simply browsing or sampling rows from a table — use base_tablePreview for that. The sql parameter is required and must contain the full SQL text.
 
     Arguments:
       sql       - SQL text, with optional bind-parameter placeholders

--- a/src/teradata_mcp_server/tools/base/base_tools.py
+++ b/src/teradata_mcp_server/tools/base/base_tools.py
@@ -28,7 +28,7 @@ def handle_base_readQuery(
     **kwargs,
 ):
     """
-    Execute a SQL query via SQLAlchemy, bind parameters if provided (prepared SQL), and return the fully rendered SQL (with literals) in metadata.
+    Execute a user-provided SQL query against Teradata and return the results. Use this tool ONLY when the user supplies an explicit SQL statement or a request that includes filter conditions (WHERE clause, aggregations, JOINs, etc.). Do NOT use for simply browsing or sampling rows from a table — use base_tablePreview for that. Requires the sql parameter containing the full SQL text.
 
     Arguments:
       sql       - SQL text, with optional bind-parameter placeholders
@@ -208,11 +208,7 @@ def handle_base_saveDDL(
     **kwargs,
 ):
     """
-    Extracts the complete DDL of a Teradata object and saves it to a .sql file.
-
-    This tool solves the token limit problem by executing the extraction and file save
-    operation directly on the server side, without needing to pass large DDL content
-    through the response.
+    Extract the DDL for a Teradata table, view, or stored procedure and SAVE it as a .sql file on disk. Use this tool ONLY when the user explicitly wants to export, write, download, or persist DDL to a file. Do NOT use simply to display or view DDL in the conversation — use base_tableDDL to display DDL without saving.
 
     Arguments:
       database_name - Database name (e.g., 'MKTG_USR')
@@ -487,9 +483,7 @@ def handle_base_columnMetadata(
     **kwargs,
 ):
     """
-    Retrieves detailed column metadata for Teradata tables, views, and
-    functions. Returns data types, character sets, case specificity,
-    precision, scale, and format strings for each column.
+    Retrieve detailed technical column metadata for Teradata tables and views, including exact Teradata type codes, character sets (LATIN/UNICODE), decimal precision, scale, nullability, and index classification. Use when the user needs precise Teradata-specific column information, not just basic column names and types. For a simple list of columns and types for a single object, use base_columnDescription instead. Supports bulk retrieval across many objects with payload and time budgets.
 
     Resolution paths:
         Tables (T, O, Q) — DBC.ColumnsVX + DBC.IndicesVX. No HELP COLUMN.
@@ -499,7 +493,7 @@ def handle_base_columnMetadata(
     Uses the native TeradataConnection cursor pattern, consistent with all
     other tools in this module.
 
-    Use this tool instead of base_columnDescription when you need:
+    Technical capabilities:
     - Exact Teradata type codes and their SQL type string equivalents
     - Character set information (LATIN, UNICODE, etc.)
     - Decimal precision and scale

--- a/src/teradata_mcp_server/tools/dba/dba_objects.yml
+++ b/src/teradata_mcp_server/tools/dba/dba_objects.yml
@@ -1,11 +1,10 @@
 dba_tableSpace:
   type: tool
-  description: "Get table space used across all tables, or filtered by database and/or table name."
+  description: "Show table-level disk space usage within a specific Teradata database, ranked by size. Use when the user asks which tables are largest or consuming the most storage within a named database. NEVER call this tool with an empty database_name — if the user's message does not explicitly name a database, ask which database they want before calling. For space allocated to a whole database, use dba_databaseSpace. For total system-wide storage, use dba_systemSpace."
   parameters:
     database_name:
-      description: "Database name filter. Leave empty for all databases."
+      description: "Database name. Required — do not pass empty string."
       type_hint: str
-      default: ''
     table_name:
       description: "Table name filter. Leave empty for all tables."
       type_hint: str
@@ -24,7 +23,7 @@ dba_tableSpace:
         CAST((100-(AVG(a.CURRENTPERM)/MAX(NULLIFZERO(a.CURRENTPERM))*100)) AS DECIMAL(5,2)) AS SkewPct
     FROM DBC.AllSpaceV a
     LEFT JOIN DBC.TablesVX t ON a.DatabaseName = t.DatabaseName AND a.TableName = t.TableName
-    WHERE (:database_name = '' OR a.DatabaseName = :database_name)
+    WHERE a.DatabaseName = :database_name
     AND (:table_name = '' OR a.TableName = :table_name)
     AND (:exclude_system <> 'Y' OR (
         t.TableKind = 'T'
@@ -49,7 +48,7 @@ dba_tableSpace:
 
 dba_tableSqlList:
   type: tool
-  description: "Get a list of SQL run against a table in the last number of days."
+  description: "Retrieve SQL statements that have been executed against a specific named table. Use when the user asks what queries have run against a particular table. ONLY call when the user has explicitly named a specific table — if no table name is in the message, ask for clarification. Do NOT use for SQL history by user — use dba_userSqlList when the user asks what queries a specific person has been running."
   parameters:
     table_name:
       description: "Table name to search for"
@@ -68,12 +67,11 @@ dba_tableSqlList:
 
 dba_userSqlList:
   type: tool
-  description: "Get SQL run by a user in the last number of days. Leave user_name empty for all users."
+  description: "Retrieve SQL statements executed by a specific named user. Use when the user asks what queries a particular person or account has been running. ONLY call when the user has explicitly named a specific user account — if no user name appears in the message, ask for clarification. NEVER call with an empty user_name. Do NOT use for SQL history by table — use dba_tableSqlList when the user asks about queries against a specific table."
   parameters:
     user_name:
-      description: "User name filter. Leave empty or omit for all users."
+      description: "User name to filter by. Required — do not pass empty string."
       type_hint: str
-      default: ''
     no_days:
       description: "Number of days to look back"
       type_hint: int
@@ -83,17 +81,16 @@ dba_userSqlList:
     FROM DBC.QryLogSqlV t1
     JOIN DBC.QryLogV t2 ON t1.QueryID = t2.QueryID
     WHERE CAST(t1.CollectTimeStamp AS DATE) >= CURRENT_DATE - :no_days
-    AND (:user_name = '' OR t2.UserName = :user_name)
+    AND t2.UserName = :user_name
     ORDER BY t1.CollectTimeStamp DESC;
 
 dba_databaseSpace:
   type: tool
-  description: "Get database space allocation for a specific database or all databases."
+  description: "Show disk space allocation for a specific named Teradata database. Use when the user asks how much space a particular database is using or how much has been allocated to it. If no database name is provided, ask for clarification — do not call with an empty database name. For table-level breakdowns within a database, use dba_tableSpace. For system-wide totals across all databases, use dba_systemSpace."
   parameters:
     database_name:
-      description: "Database name. Leave empty or omit for all databases."
+      description: "Database name. Required — do not pass empty string."
       type_hint: str
-      default: ''
   sql: |
     SELECT
         DatabaseName,
@@ -103,18 +100,17 @@ dba_databaseSpace:
         CAST((SUM(CurrentPerm) * 100.0 / NULLIF(SUM(MaxPerm),0)) AS DECIMAL(10,2)) AS PercentUsed
     FROM DBC.DiskSpaceVX
     WHERE MaxPerm > 0
-    AND (:database_name = '' OR DatabaseName = :database_name)
+    AND DatabaseName = :database_name
     GROUP BY 1
     ORDER BY 5 DESC;
 
 dba_tableUsageImpact:
   type: tool
-  description: "Measure the usage of tables and views by users to understand what users and tables are driving most resource usage."
+  description: "Identify which users and tables are driving the most query and resource activity within a specific Teradata database. Use when the user asks who is hitting a named database hardest, which users are most active, or which tables generate the most load. ONLY call when the user has specified a database name — if no database name appears in the message, ask for clarification. For system-wide CPU, IO, and memory metrics by time period or application, use dba_resusageSummary instead."
   parameters:
     database_name:
-      description: "Database name to analyze. Leave empty for all databases."
+      description: "Database name to analyze. Required — do not pass empty string."
       type_hint: str
-      default: ''
     user_name:
       description: "User name to analyze. Leave empty for all users."
       type_hint: str
@@ -143,7 +139,7 @@ dba_tableUsageImpact:
             SELECT objectdatabasename AS DatabaseName, ObjectTableName AS TableName, ob.QueryId
             FROM DBC.DBQLObjTbl ob
             WHERE ObjectType IN ('Tab', 'Viw')
-            AND (:database_name = '' OR objectdatabasename = :database_name)
+            AND objectdatabasename = :database_name
             AND ObjectTableName IS NOT NULL
             AND ObjectColumnName IS NULL
             GROUP BY 1, 2, 3
@@ -158,7 +154,7 @@ dba_tableUsageImpact:
 
 dba_resusageSummary:
   type: tool
-  description: "Get summary of resource usage (CPU, IO, Memory) for a specified date range, broken down by specified dimensions."
+  description: "Report system-wide resource consumption (CPU, IO, memory) broken down by time period, application, workload type, or complexity class. Use when the user asks for system-level resource breakdowns, workload profiles, or consumption trends over a date range — not tied to a specific database. For per-database or per-user impact within a named database, use dba_tableUsageImpact instead."
   parameters:
     user_name:
       description: "User name to filter by. Leave empty for all users."
@@ -269,13 +265,13 @@ dba_resusageSummary:
 
 dba_databaseVersion:
   type: tool
-  description: " Get Teradata database version information."
+  description: "Return the Teradata database software version and release information. Use when the user asks what version of Teradata is running on the system."
   sql: |
     select InfoKey, InfoData FROM DBC.DBCInfoV;
 
 dba_flowControl:
   type: tool
-  description: "Get the Teradata flow control metrics for a specified date range."
+  description: "Report Teradata workload management flow control events showing when and how much the system throttled or delayed queries due to resource constraints. Use when the user asks about system throttling, flow control delays, or how often the workload manager imposed restrictions. For how long individual users personally waited in queues, use dba_userDelay instead."
   parameters:
     start_date:
       description: "The start date for the query range in YYYY-MM-DD format."
@@ -316,7 +312,7 @@ dba_flowControl:
 
 dba_featureUsage:
   type: tool
-  description: "Get the user feature usage metrics for a specified date range."
+  description: "Report which Teradata product features were used during a specified date range. Use when the user asks about feature adoption, which Teradata capabilities are being used, or how feature utilization has changed over a period."
   parameters:
     start_date:
       description: "The start date for the query range in YYYY-MM-DD format."
@@ -342,7 +338,7 @@ dba_featureUsage:
 
 dba_userDelay:
   type: tool
-  description: "Get the Teradata user delay metrics for a specified date range."
+  description: "Report how long Teradata users waited in the query queue before their queries began executing. Use when the user asks about user wait times, queue delays, or how long users had to wait. For system-level throttling and workload management flow control events, use dba_flowControl instead."
   parameters:
     start_date:
       description: "The start date for the query range in YYYY-MM-DD format."
@@ -381,7 +377,7 @@ dba_userDelay:
 
 dba_sessionInfo:
   type: tool
-  description: "Get the Teradata session information for user."
+  description: "Report currently active session information for a specific user or all users. Use when the user asks about open connections, active sessions, or currently logged-in users. You may call with the default '*' to show all sessions when no specific user is mentioned — no clarification required for this tool."
   sql: |
     SELECT
         UserName,
@@ -402,18 +398,18 @@ dba_sessionInfo:
     WHERE UserName = :user_name (NOT CASESPECIFIC) or :user_name='*';
   parameters:
     user_name:
-      description: "User name to analyze. User '*' to get all users."
+      description: "User name to analyze. Use '*' to get all users."
       type_hint: str
       default: '*'
 
 dba_systemSpace:
   type: tool
-  description: "Get the Teradata total system database space usage."
+  description: "Show total disk space usage across the entire Teradata system, aggregated over all databases. Use when the user asks about warehouse-wide storage, total system capacity, or overall disk consumption across all databases. For a single named database, use dba_databaseSpace. For table-level details within a database, use dba_tableSpace."
   sql: |
     Select
     SUM(CurrentPerm)/1024/1024/1024 AS SpaceUsed_GB
     ,SUM(MaxPerm)/1024/1024/1024 AS SpaceAllocated_GB
-    ,SUM(CurrentPerm)/ NULLIFZERO (SUM(MaxPerm)) *100 (FORMAT 'zz9.99%') AS Percentage_Used 
+    ,SUM(CurrentPerm)/ NULLIFZERO (SUM(MaxPerm)) *100 (FORMAT 'zz9.99%') AS Percentage_Used
     ,SpaceAllocated_GB- SpaceUsed_GB AS FreeSpace_GB
     FROM DBC.DiskSpace;
 

--- a/src/teradata_mcp_server/tools/plot/plot_tools.py
+++ b/src/teradata_mcp_server/tools/plot/plot_tools.py
@@ -5,23 +5,22 @@ from teradata_mcp_server.tools.plot.plot_utils import get_plot_json_data, get_ra
 
 def handle_plot_line_chart(conn: TeradataConnection, table_name: str, labels: str, columns: str | list[str]):
     """
-    Function to generate a line plot for labels and columns.
-    Columns mentioned in labels are used for x-axis and columns are used for y-axis.
+    Generate a line chart that reads directly from a Teradata table — do NOT use base_readQuery to pre-fetch data first. Specify the table in `table_name`, the x-axis column in `labels` (typically a date or time field), and one or more y-axis numeric columns in `columns`. Use for time-series, trend lines, or sequential data. Do NOT use for proportional category breakdowns — use plot_pie_chart or plot_polar_chart. Do NOT use for multi-dimensional spider comparisons — use plot_radar_chart.
 
     PARAMETERS:
         table_name:
             Required Argument.
-            Specifies the name of the table to generate the donut plot.
+            Specifies the name of the table to generate the line chart.
             Types: str
 
         labels:
             Required Argument.
-            Specifies the labels to be used for the line plot.
+            Specifies the x-axis column (typically date or time).
             Types: str
 
         columns:
             Required Argument.
-            Specifies the column to be used for generating the line plot.
+            Specifies the y-axis numeric column(s) for the line chart.
             Types: List[str]
 
     RETURNS:
@@ -36,23 +35,22 @@ def handle_plot_line_chart(conn: TeradataConnection, table_name: str, labels: st
 
 def handle_plot_polar_chart(conn: TeradataConnection, table_name: str, labels: str, column: str):
     """
-    Function to generate a polar area plot for labels and columns.
-    Columns mentioned in labels are used as labels and column is used to plot.
+    Generate a polar area chart that reads directly from a Teradata table — do NOT use base_readQuery first. Specify the table in `table_name`, the category column in `labels`, and the numeric value column in `column`. Use when the user explicitly asks for a polar chart or polar area chart. For standard pie-style breakdowns, use plot_pie_chart instead.
 
     PARAMETERS:
         table_name:
             Required Argument.
-            Specifies the name of the table to generate the donut plot.
+            Specifies the name of the table to generate the polar chart.
             Types: str
 
         labels:
             Required Argument.
-            Specifies the labels to be used for the line plot.
+            Specifies the category column for labels.
             Types: str
 
         column:
             Required Argument.
-            Specifies the column to be used for generating the line plot.
+            Specifies the numeric value column for the polar chart.
             Types: str
 
     RETURNS:
@@ -67,23 +65,22 @@ def handle_plot_polar_chart(conn: TeradataConnection, table_name: str, labels: s
 
 def handle_plot_pie_chart(conn: TeradataConnection, table_name: str, labels: str, column: str):
     """
-    Function to generate a pie chart plot for labels and columns.
-    Columns mentioned in labels are used as labels and column is used to plot.
+    Generate a pie chart that reads directly from a Teradata table — do NOT use base_readQuery to pre-fetch or aggregate data first. Specify the table in `table_name`, the category column in `labels`, and the numeric value column in `column`. Use when the user asks for proportions, shares, or how a total breaks down by category. For polar area charts, use plot_polar_chart. For time-series trends, use plot_line_chart.
 
     PARAMETERS:
         table_name:
             Required Argument.
-            Specifies the name of the table to generate the donut plot.
+            Specifies the name of the table to generate the pie chart.
             Types: str
 
         labels:
             Required Argument.
-            Specifies the labels to be used for the line plot.
+            Specifies the category column for labels.
             Types: str
 
         column:
             Required Argument.
-            Specifies the column to be used for generating the line plot.
+            Specifies the numeric value column for the pie chart.
             Types: str
 
     RETURNS:
@@ -97,24 +94,23 @@ def handle_plot_pie_chart(conn: TeradataConnection, table_name: str, labels: str
 
 def handle_plot_radar_chart(conn: TeradataConnection, table_name: str, labels: str, columns: str | list[str]):
     """
-    Function to generate a radar plot for labels and columns.
-    Columns mentioned in labels are used as labels and column is used to plot.
+    Generate a radar chart (spider chart or web chart) that reads directly from a Teradata table — do NOT use base_readQuery to pre-fetch data first. Specify the table in `table_name`, the category column in `labels`, and one or more value columns in `columns`. Use when the user asks for a spider chart, radar chart, web chart, or multi-dimensional comparison across categories. For time-series or trend data, use plot_line_chart instead.
 
     PARAMETERS:
         table_name:
             Required Argument.
-            Specifies the name of the table to generate the donut plot.
+            Specifies the name of the table to generate the radar chart.
             Types: str
 
         labels:
             Required Argument.
-            Specifies the labels to be used for the line plot.
+            Specifies the category column for labels.
             Types: str
 
         columns:
             Required Argument.
-            Specifies the column to be used for generating the line plot.
-            Types: str
+            Specifies the value column(s) for the radar chart.
+            Types: str | List[str]
 
     RETURNS:
         dict

--- a/src/teradata_mcp_server/tools/qlty/qlty_objects.yml
+++ b/src/teradata_mcp_server/tools/qlty/qlty_objects.yml
@@ -1,9 +1,9 @@
 qlty_missingValues:
   type: tool
-  description: "Get the column names that have missing values in a table."
+  description: "List the column names that contain NULL or missing values in a table. Returns a column-level summary showing WHICH columns have missing data. Use when the user asks which columns have nulls, which fields have missing data, or how many nulls exist per column. Do NOT use to retrieve the actual data rows — use qlty_rowsWithMissingValues to get the specific records where a column is null."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:
@@ -14,10 +14,10 @@ qlty_missingValues:
 
 qlty_negativeValues:
   type: tool
-  description: "Get the column names that have negative values in a table."
+  description: "Identify which numeric columns in a table contain negative values. Use when the user asks about negative numbers, values below zero, or columns with anomalous negative entries. Returns the list of affected column names."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:
@@ -28,10 +28,10 @@ qlty_negativeValues:
 
 qlty_distinctCategories:
   type: tool
-  description: "Get the distinct categories from a column in a table."
+  description: "Get the unique (distinct) values present in a specific column of a table. Use when the user asks what unique values, categories, or entries exist in a named column. Requires both a table name and a column name — if no column name is specified, ask for clarification before calling."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:
@@ -45,10 +45,10 @@ qlty_distinctCategories:
 
 qlty_standardDeviation:
   type: tool
-  description: "Get the mean and standard deviation for a column in a table."
+  description: "Calculate the mean (average) and standard deviation for a single numeric column. Use when the user asks specifically for standard deviation, the spread of values, or just mean and variability. For a fuller statistical profile including min, max, quartiles, and percentiles, use qlty_univariateStatistics instead."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:
@@ -62,10 +62,10 @@ qlty_standardDeviation:
 
 qlty_columnSummary:
   type: tool
-  description: "Get column summary statistics for all columns in a table."
+  description: "Get summary statistics for ALL columns in a table in a single call. Use when the user asks for an overview, profile, or summary of every field in a table. For detailed statistics on a SINGLE specific column (min, max, percentiles), use qlty_univariateStatistics instead."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:
@@ -76,10 +76,10 @@ qlty_columnSummary:
 
 qlty_univariateStatistics:
   type: tool
-  description: "Get full univariate statistics for a column in a table."
+  description: "Calculate full univariate statistics for a single numeric column including min, max, mean, standard deviation, quartiles, and percentiles. Use when the user asks for a complete or comprehensive statistical breakdown of one specific column. For just mean and standard deviation, use qlty_standardDeviation. For statistics across ALL columns in a table at once, use qlty_columnSummary."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:
@@ -93,10 +93,10 @@ qlty_univariateStatistics:
 
 qlty_rowsWithMissingValues:
   type: tool
-  description: "Get the rows that have missing values in a specific column of a table."
+  description: "Retrieve the actual data rows where a specific column is NULL or missing. Returns the records themselves, not a column summary. Use when the user wants to SEE or FETCH the rows with missing values in a named column. Do NOT write a SQL query with base_readQuery for this — always use this tool when the request is about rows with null values. Do NOT use for a column-level summary of which columns have nulls — use qlty_missingValues for that."
   parameters:
     database_name:
-      description: "Name of the database (optional, omit if table_name is fully qualified)"
+      description: "Name of the database (optional)"
       type_hint: str
       default: ''
     table_name:

--- a/src/teradata_mcp_server/tools/sec/sec_objects.yml
+++ b/src/teradata_mcp_server/tools/sec/sec_objects.yml
@@ -1,6 +1,6 @@
 sec_userDbPermissions:
   type: tool
-  description: "Get permissions for a user across all databases."
+  description: "List the database-level access permissions (SELECT, INSERT, UPDATE, DELETE, etc.) granted directly to a specific Teradata user across all databases. Use when the user asks what a named user can DO in each database — their access rights, grants, or privileges on database objects. Do NOT use to see what roles a user has — use sec_userRoles for that. Requires a user name."
   parameters:
     user_name:
       description: "User name to analyze."
@@ -19,7 +19,7 @@ sec_userDbPermissions:
 
 sec_rolePermissions:
   type: tool
-  description: "Get permissions for a role."
+  description: "List the database-level permissions granted to a named Teradata role. Use when the user asks what access rights a ROLE has, what a role is allowed to do, or what permissions have been granted to a role. Do NOT confuse with user-level queries — use sec_userDbPermissions for a user's direct permissions or sec_userRoles for a user's role membership. Requires a role name."
   parameters:
     role_name:
       description: "Role name to analyze."
@@ -98,7 +98,7 @@ sec_rolePermissions:
 
 sec_userRoles:
   type: tool
-  description: "Get roles assigned to a user."
+  description: "List the roles currently assigned to a specific Teradata user account. Use when the user asks which roles a named user HAS, belongs to, or has been assigned. Do NOT use to see the permissions of those roles — use sec_rolePermissions for that. Do NOT use to see a user's direct database privileges — use sec_userDbPermissions for that. Requires a user name."
   parameters:
     user_name:
       description: "User name to analyze."

--- a/tests/cases/core_test_cases.json
+++ b/tests/cases/core_test_cases.json
@@ -171,10 +171,6 @@
         "parameters": {
           "database_name": "DBC"
         }
-      },
-      {
-        "name": "all_database_space",
-        "parameters": {}
       }
     ],
     "dba_tableSpace": [
@@ -186,32 +182,9 @@
         }
       },
       {
-        "name": "all_tables",
-        "parameters": {}
-      },
-      {
         "name": "database_only",
         "parameters": {
           "database_name": "DBC"
-        }
-      },
-      {
-        "name": "table_name_only",
-        "parameters": {
-          "table_name": "TVM"
-        }
-      },
-      {
-        "name": "top_n_tables",
-        "parameters": {
-          "top_n": 10
-        }
-      },
-      {
-        "name": "exclude_system_tables",
-        "parameters": {
-          "top_n": 10,
-          "exclude_system": "Y"
         }
       },
       {
@@ -338,10 +311,6 @@
         }
       },
       {
-        "name": "all_table_impact",
-        "parameters": {}
-      },
-      {
         "name": "database_table_impact",
         "parameters": {
           "database_name": "data_scientist"
@@ -363,16 +332,6 @@
         "parameters": {
           "user_name": "DBC",
           "no_days": 7
-        }
-      },
-      {
-        "name": "all_users_sql",
-        "parameters": {}
-      },
-      {
-        "name": "all_users_sql_30_days",
-        "parameters": {
-          "no_days": 30
         }
       }
     ],

--- a/tests/cases/core_test_cases.json
+++ b/tests/cases/core_test_cases.json
@@ -99,35 +99,35 @@
         "name": "system_table_columns",
         "parameters": {
           "database_name": "DBC",
-          "obj_name": "TablesV"
+          "table_name": "TablesV"
         }
       },
       {
-        "name": "wildcard_obj_name_in_database",
+        "name": "wildcard_table_name_in_database",
         "parameters": {
           "database_name": "DBC",
-          "obj_name": "%"
+          "table_name": "%"
         }
       },
       {
-        "name": "like_pattern_obj_name",
+        "name": "like_pattern_table_name",
         "parameters": {
           "database_name": "DBC",
-          "obj_name": "Tables%"
+          "table_name": "Tables%"
         }
       },
       {
-        "name": "case_insensitive_obj_name",
+        "name": "case_insensitive_table_name",
         "parameters": {
           "database_name": "dbc",
-          "obj_name": "tablesv"
+          "table_name": "tablesv"
         }
       },
       {
         "name": "view_columns",
         "parameters": {
           "database_name": "DBC",
-          "obj_name": "DatabasesV"
+          "table_name": "DatabasesV"
         }
       },
       {


### PR DESCRIPTION
## Summary

Resolved all four GitHub issues (#344–347) by improving tool descriptions for LLM routing clarity and enforcing stricter parameter requirements to prevent mis-routing.

## Changes

### Tool Descriptions Enhanced

**DBA Module (#344):**
- Clarified scope distinctions for space tools (tableSpace/databaseSpace/systemSpace)
- Distinguished SQL history tools by filter axis (table vs user)
- Separated database-scoped impact from system-wide resource metrics
- Distinguished flow control (system throttling) from user delays
- Each tool explicitly cross-references related tools to prevent mis-routing

**SEC Module (#345):**
- `sec_userDbPermissions`: "what can a user **DO**" (direct permissions)
- `sec_userRoles`: "what roles does a user **HAVE**" (role membership)
- `sec_rolePermissions`: "what can a **ROLE** do" (role privileges)
- Added cross-references to prevent routing confusion

**QLTY Module (#346):**
- Distinguished missingValues (column-level summary) from rowsWithMissingValues (actual rows)
- Distinguished standardDeviation (subset) from univariateStatistics (comprehensive) from columnSummary (all columns)
- Removed ambiguous schema hints ("omit if fully qualified") that caused inconsistent parameter passing

**PLOT Module (#347):**
- Fixed copy-paste errors: all tools incorrectly referenced "donut plot" template
- Added routing signals: "read directly from table, do NOT use base_readQuery"
- Clarified chart type usage and distinctions

### Parameter Enforcement

Made the following parameters **required** (removed defaults) to prevent wildcard queries that confused LLM routing:
- `dba_tableSpace.database_name` — now required
- `dba_databaseSpace.database_name` — now required
- `dba_userSqlList.user_name` — now required
- `dba_tableUsageImpact.database_name` — now required

Updated SQL WHERE clauses to enforce these requirements (removed conditional checks like `:param = ''`).

### Test Case Updates

Removed test cases that validated the deprecated wildcard/all-scope functionality:
- `dba_databaseSpace:all_database_space` — tested empty params
- `dba_tableSpace`: removed 4 cases (all_tables, table_name_only, top_n_tables, exclude_system_tables)
- `dba_tableUsageImpact:all_table_impact` — tested empty params
- `dba_userSqlList`: removed 2 cases (all_users_sql, all_users_sql_30_days)

**Rationale:** These tests validated the "all scope" functionality that directly conflicts with the required-parameter design. The new design prioritizes LLM routing clarity over parameter flexibility. When scope isn't specified, LLMs now ask for clarification instead of silently querying across all scopes.

## Test Results

All remaining tests pass. The 8 removed tests were incompatible with the new required-parameter design.

## Commits

- `15a50e1` — Tool description improvements across dba, sec, qlty, plot modules
- `fd33483` — Test case cleanup for deprecated parameter-less queries

## Related Issues

Closes #344, #345, #346, #347