### PR TITLE
Set sql_ tools as writable

### DIFF
--- a/src/teradata_mcp_server/app.py
+++ b/src/teradata_mcp_server/app.py
@@ -62,7 +62,7 @@ _PREFIX_ANNOTATIONS: dict[str, ToolAnnotations] = {
     "rag_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
     "qlty_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
     "graph_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
-    "sql_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+    "sql_": ToolAnnotations(readOnlyHint=False, idempotentHint=True),
     "plot_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
     "tdvs_": ToolAnnotations(readOnlyHint=True, idempotentHint=True),
     "bar_": ToolAnnotations(readOnlyHint=False, destructiveHint=True),


### PR DESCRIPTION
## Summary
- SQL tools can perform writes and modifications, not just read-only queries
- Updated annotation to reflect this capability

## Test plan
- [ ] Verify sql_ tools are available with writable permissions in the UI